### PR TITLE
Added an MGSSyntaxErrors object and associated protocols.

### DIFF
--- a/Applications/MGSFragariaView/AppDelegate.m
+++ b/Applications/MGSFragariaView/AppDelegate.m
@@ -75,10 +75,7 @@
 
 
 	/* Sample Syntax Error Definitions */
-    //self.viewTop.syntaxErrors = [self makeSyntaxErrors];
-
-
-
+    self.viewTop.syntaxErrors = [self makeSyntaxErrors];
 }
 
 
@@ -184,44 +181,47 @@
 /*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
 	makeSyntaxErrors
  *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (NSArray *)makeSyntaxErrors
+- (MGSSyntaxErrors *)makeSyntaxErrors
 {
-    SMLSyntaxError *syntaxError = [SMLSyntaxError new];
-    syntaxError.description = @"Syntax errors can be defined";
-    syntaxError.line = 4;
-    syntaxError.character = 3;
-    syntaxError.length = 5;
-    syntaxError.hideWarning = YES;
-    syntaxError.warningStyle = kMGSErrorError;
-    //syntaxError.customBackgroundColor = [NSColor magentaColor];
+    MGSSyntaxErrors *error = [[MGSSyntaxErrors alloc] init];
 
-    SMLSyntaxError *syntaxError2 = [SMLSyntaxError new];
-    syntaxError2.description = @"Multiple syntax errors can be defined for the same line, too.";
-    syntaxError2.line = 4;
-    syntaxError2.character = 12;
-    syntaxError2.length = 7;
-    syntaxError2.hideWarning = NO;
-    syntaxError2.warningStyle = kMGSErrorAccess;
-    //syntaxError2.customBackgroundColor = syntaxError.customBackgroundColor; // messy coloring if you use different colors on the same line!
+    [error addErrorFromDictionary:@{
+                                   @"description"  : @"Syntax errors can be defined.",
+                                   @"line"         : @(4),
+                                   @"character"    : @(3),
+                                   @"length"       : @(5),
+                                   @"hidden"       : @(YES),
+                                   @"warningStyle" : @(kMGSErrorError),
+                                   }];
 
-    SMLSyntaxError *syntaxError3 = [SMLSyntaxError new];
-    syntaxError3.description = @"This error will appear on top of a line break.";
-    syntaxError3.line = 6;
-    syntaxError3.character = 1;
-    syntaxError3.length = 2;
-    syntaxError3.hideWarning = NO;
-    syntaxError3.warningStyle = kMGSErrorConfig;
-    //syntaxError2.customBackgroundColor = syntaxError.customBackgroundColor; // messy coloring if you use different colors on the same line!
+    [error addErrorFromDictionary:@{
+                                    @"description"  : @"Multiple syntax errors can be defined for the same line, too.",
+                                    @"line"         : @(4),
+                                    @"character"    : @(12),
+                                    @"length"       : @(7),
+                                    @"hidden"       : @(NO),
+                                    @"warningStyle" : @(kMGSErrorAccess),
+                                    }];
 
-    SMLSyntaxError *syntaxError4 = [SMLSyntaxError new];
-    syntaxError4.description = @"This error will be hidden.";
-    syntaxError4.line = 10;
-    syntaxError4.character = 12;
-    syntaxError4.length = 7;
-    syntaxError4.hideWarning = NO;
-    //syntaxError2.customBackgroundColor = syntaxError.customBackgroundColor; // messy coloring if you use different colors on the same line!
+    [error addErrorFromDictionary:@{
+                                    @"description"  : @"This error will appear on top of a line break.",
+                                    @"line"         : @(6),
+                                    @"character"    : @(1),
+                                    @"length"       : @(2),
+                                    @"hidden"       : @(NO),
+                                    @"warningStyle" : @(kMGSErrorConfig),
+                                    }];
 
-    return @[syntaxError, syntaxError2, syntaxError3, syntaxError4];
+    [error addErrorFromDictionary:@{
+                                    @"description"  : @"This error will be hidden.",
+                                    @"line"         : @(10),
+                                    @"character"    : @(12),
+                                    @"length"       : @(7),
+                                    @"hidden"       : @(YES),
+                                    @"warningStyle" : @(kMGSErrorError),
+                                    }];
+
+    return error;
 }
 
 @end

--- a/Applications/MGSFragariaView/Base.lproj/MainMenu.xib
+++ b/Applications/MGSFragariaView/Base.lproj/MainMenu.xib
@@ -22,9 +22,9 @@
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
         <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
             <items>
-                <menuItem title="JSDFragariaView Demo" id="1Xt-HY-uBw">
+                <menuItem title="MGSFragariaView Demo" id="1Xt-HY-uBw">
                     <modifierMask key="keyEquivalentModifierMask"/>
-                    <menu key="submenu" title="JSDFragariaView Demo" systemMenu="apple" id="uQy-DD-JDr">
+                    <menu key="submenu" title="MGSFragariaView Demo" systemMenu="apple" id="uQy-DD-JDr">
                         <items>
                             <menuItem title="About JSDFragariaView Demo" id="5kV-Vb-QxS">
                                 <modifierMask key="keyEquivalentModifierMask"/>
@@ -744,11 +744,11 @@
                 </menuItem>
             </items>
         </menu>
-        <window title="JSDFragariaView Demo" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+        <window title="MGSFragariaView Demo" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" userLabel="MGSFragariaView Demo">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/Fragaria.xcodeproj/project.pbxproj
+++ b/Fragaria.xcodeproj/project.pbxproj
@@ -105,6 +105,9 @@
 		D0C146891A8769C100DDE90A /* messagesPanic.icns in Resources */ = {isa = PBXBuildFile; fileRef = D0C146831A8769C100DDE90A /* messagesPanic.icns */; };
 		D0E520F51A88EB6B005CB80B /* MGSFragariaPreferencesController.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E520F31A88EB6B005CB80B /* MGSFragariaPreferencesController.h */; };
 		D0E520F61A88EB6B005CB80B /* MGSFragariaPreferencesController.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E520F41A88EB6B005CB80B /* MGSFragariaPreferencesController.m */; };
+		D0E520FB1A8F38B3005CB80B /* MGSSyntaxErrorProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E520FA1A8F38B3005CB80B /* MGSSyntaxErrorProtocols.h */; };
+		D0E520FE1A8F6EDD005CB80B /* MGSSyntaxErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = D0E520FC1A8F6EDD005CB80B /* MGSSyntaxErrors.h */; };
+		D0E520FF1A8F6EDD005CB80B /* MGSSyntaxErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E520FD1A8F6EDD005CB80B /* MGSSyntaxErrors.m */; };
 		E373BF131718A64700D71602 /* SMLAutoCompleteDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E373BF121718A64700D71602 /* SMLAutoCompleteDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E3AA871B16E1817800585940 /* editor-breakpoint.png in Resources */ = {isa = PBXBuildFile; fileRef = E3AA871A16E1817800585940 /* editor-breakpoint.png */; };
 		E3BBA50B16E52FE600D89923 /* editor-breakpoint-0.png in Resources */ = {isa = PBXBuildFile; fileRef = E3BBA50816E52FE600D89923 /* editor-breakpoint-0.png */; };
@@ -267,6 +270,9 @@
 		D0E520F21A88E577005CB80B /* Fragaria_Document-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Fragaria_Document-Info.plist"; path = "Applications/Fragaria_Document-Info.plist"; sourceTree = "<group>"; };
 		D0E520F31A88EB6B005CB80B /* MGSFragariaPreferencesController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSFragariaPreferencesController.h; sourceTree = "<group>"; };
 		D0E520F41A88EB6B005CB80B /* MGSFragariaPreferencesController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSFragariaPreferencesController.m; sourceTree = "<group>"; };
+		D0E520FA1A8F38B3005CB80B /* MGSSyntaxErrorProtocols.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSSyntaxErrorProtocols.h; sourceTree = "<group>"; };
+		D0E520FC1A8F6EDD005CB80B /* MGSSyntaxErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSSyntaxErrors.h; sourceTree = "<group>"; };
+		D0E520FD1A8F6EDD005CB80B /* MGSSyntaxErrors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSSyntaxErrors.m; sourceTree = "<group>"; };
 		E373BF121718A64700D71602 /* SMLAutoCompleteDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMLAutoCompleteDelegate.h; sourceTree = "<group>"; };
 		E3AA871A16E1817800585940 /* editor-breakpoint.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "editor-breakpoint.png"; sourceTree = "<group>"; };
 		E3BBA50816E52FE600D89923 /* editor-breakpoint-0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "editor-breakpoint-0.png"; sourceTree = "<group>"; };
@@ -390,7 +396,6 @@
 				AB6C86C2160FA2B500488AF2 /* MGSGlyphGenerator.m */,
 				013278651A81610E00D2DCA5 /* Syntax Definition Manager */,
 				01BB1BEE1A7964DC006C0056 /* Gutter Text View */,
-				AB69B659118B75E100903D1D /* Error Popover */,
 			);
 			name = "Text View Components";
 			sourceTree = "<group>";
@@ -539,15 +544,6 @@
 			name = "NSDocument based";
 			sourceTree = "<group>";
 		};
-		AB69B659118B75E100903D1D /* Error Popover */ = {
-			isa = PBXGroup;
-			children = (
-				E3C1850117175ED900801FE5 /* SMLErrorPopOver.h */,
-				E3C1850217175ED900801FE5 /* SMLErrorPopOver.m */,
-			);
-			name = "Error Popover";
-			sourceTree = "<group>";
-		};
 		AB69B752118B82DF00903D1D /* Framework */ = {
 			isa = PBXGroup;
 			children = (
@@ -595,8 +591,7 @@
 				D0C146741A871A0B00DDE90A /* MGSFragariaView.m */,
 				AB69B753118B830700903D1D /* MGSFragaria.h */,
 				AB41C1041191FFCB004F0CB5 /* MGSFragaria.m */,
-				E3D4B2751714D89700BB2CC6 /* SMLSyntaxError.h */,
-				E3D4B2761714D89700BB2CC6 /* SMLSyntaxError.m */,
+				D0E520F91A8F3820005CB80B /* Error Components */,
 				0191FA831A882B0F0099B50D /* Global Private Headers */,
 				AB83887D171E94C5004408F4 /* NS Categories */,
 				01BB1BEC1A7962C7006C0056 /* Text View Components */,
@@ -627,6 +622,20 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		D0E520F91A8F3820005CB80B /* Error Components */ = {
+			isa = PBXGroup;
+			children = (
+				D0E520FA1A8F38B3005CB80B /* MGSSyntaxErrorProtocols.h */,
+				E3D4B2751714D89700BB2CC6 /* SMLSyntaxError.h */,
+				E3D4B2761714D89700BB2CC6 /* SMLSyntaxError.m */,
+				D0E520FC1A8F6EDD005CB80B /* MGSSyntaxErrors.h */,
+				D0E520FD1A8F6EDD005CB80B /* MGSSyntaxErrors.m */,
+				E3C1850117175ED900801FE5 /* SMLErrorPopOver.h */,
+				E3C1850217175ED900801FE5 /* SMLErrorPopOver.m */,
+			);
+			name = "Error Components";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -643,6 +652,7 @@
 				AB257FE4129B1CE300A3FF76 /* MGSTextMenuController.h in Headers */,
 				0191FA851A884CC20099B50D /* MGSExtraInterfaceController.h in Headers */,
 				017FD58A1A7A992700B305FB /* MGSLineNumberView.h in Headers */,
+				D0E520FE1A8F6EDD005CB80B /* MGSSyntaxErrors.h in Headers */,
 				AB69B754118B830700903D1D /* MGSFragaria.h in Headers */,
 				0191FA7D1A881F6E0099B50D /* MGSDragOperationDelegate.h in Headers */,
 				AB257FCE129B1BF500A3FF76 /* SMLTextView.h in Headers */,
@@ -653,6 +663,7 @@
 				E373BF131718A64700D71602 /* SMLAutoCompleteDelegate.h in Headers */,
 				AB8387AA171B4505004408F4 /* SMLSyntaxColouringDelegate.h in Headers */,
 				AB8387C5171D6115004408F4 /* SMLSyntaxDefinition.h in Headers */,
+				D0E520FB1A8F38B3005CB80B /* MGSSyntaxErrorProtocols.h in Headers */,
 				ABC578ED1603D7ED0040B3FB /* MGSFragariaTextEditingPrefsViewController.h in Headers */,
 				E3C1850317175ED900801FE5 /* SMLErrorPopOver.h in Headers */,
 			);
@@ -895,6 +906,7 @@
 				E3D4B2781714D89700BB2CC6 /* SMLSyntaxError.m in Sources */,
 				E3C1850417175ED900801FE5 /* SMLErrorPopOver.m in Sources */,
 				0132786A1A81650300D2DCA5 /* MGSSyntaxDefinition.m in Sources */,
+				D0E520FF1A8F6EDD005CB80B /* MGSSyntaxErrors.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Fragaria.xcodeproj/project.pbxproj
+++ b/Fragaria.xcodeproj/project.pbxproj
@@ -249,10 +249,10 @@
 		D0C145C21A85E1FD00DDE90A /* SMLTextView+MGSDragging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SMLTextView+MGSDragging.h"; sourceTree = "<group>"; };
 		D0C145C31A85E1FD00DDE90A /* SMLTextView+MGSDragging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SMLTextView+MGSDragging.m"; sourceTree = "<group>"; };
 		D0C1464C1A87196200DDE90A /* MGSFragariaView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MGSFragariaView.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D0C1464F1A87196200DDE90A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Applications/MGSFragariaView/Info.plist; sourceTree = "<group>"; };
-		D0C146501A87196200DDE90A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = ../Applications/MGSFragariaView/AppDelegate.h; sourceTree = "<group>"; };
-		D0C146511A87196200DDE90A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = ../Applications/MGSFragariaView/AppDelegate.m; sourceTree = "<group>"; };
-		D0C146531A87196200DDE90A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../Applications/MGSFragariaView/main.m; sourceTree = "<group>"; };
+		D0C1464F1A87196200DDE90A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Applications/MGSFragariaView/Info.plist; sourceTree = "<group>"; };
+		D0C146501A87196200DDE90A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = Applications/MGSFragariaView/AppDelegate.h; sourceTree = "<group>"; };
+		D0C146511A87196200DDE90A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = Applications/MGSFragariaView/AppDelegate.m; sourceTree = "<group>"; };
+		D0C146531A87196200DDE90A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Applications/MGSFragariaView/main.m; sourceTree = "<group>"; };
 		D0C146581A87196200DDE90A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		D0C146731A871A0B00DDE90A /* MGSFragariaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSFragariaView.h; sourceTree = "<group>"; };
 		D0C146741A871A0B00DDE90A /* MGSFragariaView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSFragariaView.m; sourceTree = "<group>"; };
@@ -578,7 +578,7 @@
 				01BB1BF21A79AA15006C0056 /* MGSSimpleBreakpointDelegate.m */,
 				AB648E2311FB37D200AEF7BD /* NSDocument based */,
 				AB648E2211FB37AF00AEF7BD /* Simple */,
-				D0C1464D1A87196200DDE90A /* MGSFragariaView */,
+				D0E520F71A8F3256005CB80B /* MGSFragariaView */,
 			);
 			name = Applications;
 			sourceTree = "<group>";
@@ -606,19 +606,19 @@
 			name = Fragaria;
 			sourceTree = "<group>";
 		};
-		D0C1464D1A87196200DDE90A /* MGSFragariaView */ = {
+		D0E520F71A8F3256005CB80B /* MGSFragariaView */ = {
 			isa = PBXGroup;
 			children = (
 				D0C146501A87196200DDE90A /* AppDelegate.h */,
 				D0C146511A87196200DDE90A /* AppDelegate.m */,
 				D0C146571A87196200DDE90A /* MainMenu.xib */,
 				D0C146771A871AF300DDE90A /* Lorem.html */,
-				D0C1464E1A87196200DDE90A /* Supporting Files */,
+				D0E520F81A8F326C005CB80B /* Supporting Files */,
 			);
-			path = MGSFragariaView;
+			name = MGSFragariaView;
 			sourceTree = "<group>";
 		};
-		D0C1464E1A87196200DDE90A /* Supporting Files */ = {
+		D0E520F81A8F326C005CB80B /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
 				D0C1464F1A87196200DDE90A /* Info.plist */,
@@ -973,7 +973,7 @@
 				D0C146581A87196200DDE90A /* Base */,
 			);
 			name = MainMenu.xib;
-			path = ../Applications/MGSFragariaView;
+			path = Applications/MGSFragariaView;
 			sourceTree = "<group>";
 		};
 		D0C146771A871AF300DDE90A /* Lorem.html */ = {
@@ -982,7 +982,7 @@
 				D0C146781A871AF300DDE90A /* Base */,
 			);
 			name = Lorem.html;
-			path = ../Applications/MGSFragariaView;
+			path = Applications/MGSFragariaView;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/MGSFragaria.h
+++ b/MGSFragaria.h
@@ -48,6 +48,7 @@ extern NSString * const ro_MGSFOSyntaxColouring; // readonly
 #import "MGSBreakpointDelegate.h"
 #import "MGSDragOperationDelegate.h"
 #import "SMLSyntaxError.h"
+#import "MGSSyntaxErrors.h"
 #import "SMLSyntaxColouringDelegate.h"
 #import "SMLSyntaxDefinition.h"
 
@@ -119,8 +120,8 @@ extern NSString * const ro_MGSFOSyntaxColouring; // readonly
 - (void)setSyntaxDefinitionName:(NSString *)value;
 - (NSString *)syntaxDefinitionName;
 
-- (void)setSyntaxErrors:(NSArray *)errors;
-- (NSArray *)syntaxErrors;
+- (void)setSyntaxErrors:(id <MGSSyntaxErrors>)errors;
+- (id <MGSSyntaxErrors>)syntaxErrors;
 + (NSImage *)imageNamed:(NSString *)name;
 
 @end

--- a/MGSFragaria.m
+++ b/MGSFragaria.m
@@ -737,7 +737,7 @@ char kcLineWrapPrefChanged;
  - setSyntaxErrors:
  
  */
-- (void)setSyntaxErrors:(NSArray *)errors
+- (void)setSyntaxErrors:(id <MGSSyntaxErrors>)errors
 {
     SMLSyntaxColouring *syntaxColouring = [docSpec valueForKey:ro_MGSFOSyntaxColouring];
     syntaxColouring.syntaxErrors = errors;
@@ -753,8 +753,9 @@ char kcLineWrapPrefChanged;
  - syntaxErrors
  
  */
-- (NSArray *)syntaxErrors
+- (id <MGSSyntaxErrors>)syntaxErrors
 {
+    // @todo: part of @7, why is SMLSyntaxColouring the owner of this?
     SMLSyntaxColouring *syntaxColouring = [docSpec valueForKey:ro_MGSFOSyntaxColouring];
     return syntaxColouring.syntaxErrors;
 }

--- a/MGSFragariaView.h
+++ b/MGSFragariaView.h
@@ -50,7 +50,7 @@
 
 @property (assign) NSString *documentName;
 
-@property (assign) NSArray *syntaxErrors;
+@property (assign) id <MGSSyntaxErrors> syntaxErrors;
 
 @property (assign) BOOL showsWarningsInGutter;
 

--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -272,12 +272,12 @@
 /*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
 	syntaxErrors
  *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setSyntaxErrors:(NSArray *)syntaxErrors
+- (void)setSyntaxErrors:(id <MGSSyntaxErrors>)syntaxErrors
 {
 	self.fragaria.syntaxErrors = syntaxErrors;
 }
 
-- (NSArray *)syntaxErrors
+- (id <MGSSyntaxErrors>)syntaxErrors
 {
 	return self.fragaria.syntaxErrors;
 }

--- a/MGSLineNumberView.h
+++ b/MGSLineNumberView.h
@@ -43,6 +43,7 @@
  */
 
 @protocol MGSBreakpointDelegate;
+@protocol MGSSyntaxErrors;
 
 
 @interface MGSLineNumberView : NSRulerView
@@ -67,7 +68,7 @@
 @property (nonatomic) NSColor *backgroundColor;
 @property (nonatomic) CGFloat minimumWidth;
 @property (nonatomic) NSUInteger startingLineNumber;
-@property (nonatomic) NSArray *syntaxErrors;
+@property (nonatomic) id <MGSSyntaxErrors> syntaxErrors;
 @property (nonatomic) BOOL *showsWarnings;
 
 - (id)initWithScrollView:(NSScrollView *)aScrollView;

--- a/MGSSyntaxErrorProtocols.h
+++ b/MGSSyntaxErrorProtocols.h
@@ -1,0 +1,139 @@
+//
+//  MGSSyntaxErrorProtocols.h
+//  Fragaria
+//
+//  Created by Jim Derry on 2/14/15.
+//
+//
+
+/**
+ *   MGSSyntaxErrorProtocols.h defines the protocols for objects
+ *   interacting with Fragaria to provide error services.
+ **/
+
+
+// @todo: defaults colors, default properties, incorporate the popup, etc.
+
+#import <Foundation/Foundation.h>
+
+
+#pragma mark - Typedef MGSSyntaxErrorType
+/**
+ *   MGSSyntaxErrorType
+ *    An enum indicating the type of syntax error. Classes
+ *    adhering to this protocol will import this header,
+ *    exposing these values to you.
+ **/
+typedef NS_ENUM(NSInteger, MGSSyntaxErrorType)
+{
+    kMGSErrorDefault  = 0, ///< Indicates the default error type.
+    kMGSErrorAccess   = 1, ///< Indicates an access error.
+    kMGSErrorConfig   = 2, ///< Indicates configuration error.
+    kMGSErrorDocument = 3, ///< Indicates a document error.
+    kMGSErrorInfo     = 4, ///< Indicates an information error (e.g., to show info that may not be an error).
+    kMGSErrorWarning  = 5, ///< Indicates a warning.
+    kMGSErrorError    = 6, ///< Indicates an error.
+    kMGSErrorPanic    = 7  ///< Indicates a panic.
+};
+
+
+#pragma mark - Protocol MGSSyntaxError
+/**
+ *   MGSSyntaxError
+ *    Defines the protocol for individual syntax errors and is expressed
+ *    by default in the class `SMLSyntaxError`.
+ **/
+@protocol MGSSyntaxError
+
+/// @name Class methods
+
++ (instancetype) errorWithDictionary:(NSDictionary *)dictionary;   ///< Returns a <MGSSyntaxError> objct from the values in an NSDictionary.
+
++ (NSImage *)imageForWarningStyle:(MGSSyntaxErrorType)style;       ///< A convenience class method that returns an image for a particular error type.
+
+
+/// @name Instance methods
+
+- (instancetype)initWithDictionary:(NSDictionary *)errorDict;      ///< Intializes a new instance from an NSDictionary with keys being the property name.
+
+
+/// @name Properties
+
+@property (nonatomic,assign) int line;                             ///< The line in which the error occurs.
+@property (nonatomic,assign) int character;                        ///< The character position in the line where the error begins.
+@property (nonatomic,assign) int length;                           ///< The length of the error. Used to highlight individual errors.
+@property (nonatomic,copy) NSString* description;                  ///< Text to describe the error.
+@property (nonatomic,copy) NSString* code;                         ///< Unknown. @todo: This isn't used in source. Perhaps delete it.
+@property (nonatomic,assign) BOOL hidden;                          ///< Indicates if this particular error must be hidden.
+@property (nonatomic,copy) NSColor *errorLineHighlightColor;       ///< Indicates the color to use to highlight the line when an error occurs.
+@property (nonatomic,copy) NSColor *errorBackgroundHighlightColor; ///< Indicates the color to use to highlight error text (background).
+@property (nonatomic,copy) NSColor *errorForegroundHilightColor;   ///< Indicates the folor to use to highlight error text (foreground).
+
+/**
+ *   Indicates the overall styling of the warning given when the users accesses
+ *   syntax errors. See `MGSSyntaxErrorType` for the minimum warning levels expected
+ *   by conforming classes.
+ *
+ *   @discussion Conforming classes may want to provide different appearance for
+ *     different types of warnings. `MGSSyntaxErrors`, for example will produce
+ *     different images for different values of warningStyle.
+ **/
+@property (nonatomic,assign) MGSSyntaxErrorType warningStyle;
+
+@property (nonatomic,readonly) NSImage *warningImage;      ///< Returns an image appropriate to the warningStyle.
+
+@end
+
+
+#pragma mark - Protocol MGSSyntaxErrors
+/**
+ *   MGSSyntaxErrors
+ *    Defines the protocol for a syntax error manager and utility class
+ *    that manages multiple syntax errors and provides services to other
+ *    components. It is expressed by default in the class `MGSSyntaxErrors`.
+ *
+ *    Applications that generate errors are still expected to manage all of
+ *    their own errors. As such the protocol does not provide methods for
+ *    managing syntax errors beyond adding them and clearing them.
+ **/
+@protocol MGSSyntaxErrors
+
+/// @name Instance Methods - Instantiation
+
+- (instancetype)initWithErrorsFromArray:(NSArray *)errors; ///< Initilizes a new object from a dictionary of id <MGSSyntaxError> objects.
+
+
+/// @name Instance Methods - Setting and Clearing Errors
+
+- (void)addErrorFromDictionary:(NSDictionary*)error;       ///< Adds a new error from a dictionary where keys are <MGSSyntaxError> properties.
+
+- (void)addError:(id<MGSSyntaxError>)error;                ///< Adds a new error from an id <MGSSyntaxError> object.
+
+
+/// @name Instance Methods - Accessing error data
+
+
+- (NSArray *)linesWithErrors;                               ///< Returns an array of NSNumber containing a list of lines that have errors, ignoring hidden errors.
+
+- (NSUInteger)errorCountForLine:(NSInteger)line;                  ///< Returns the number of errors at the given line, ignoring hidden errors.
+
+/**
+ * Returns the error at the given line., ignoring hidden errors.
+ *   @discussion If there are multiple errors, then the method
+ *   will return the first error with the highest severity.
+ **/
+- (id<MGSSyntaxError>)errorForLine:(NSInteger)line;
+
+- (NSArray *)errorsForLine:(NSInteger)line;                       ///< Returns all of the errors at the given line as an array of <MGSSyntaxError> objects, ignoring hidden errors.
+
+- (NSArray *)nonHiddenErrors;                               ///< Returns an array of all errors which are not set to hidden.
+
+
+/// @name Properties
+
+@property (nonatomic, strong) NSArray *syntaxErrors;        ///< Exposes id <MGSSyntaxError> objects for application use. Does *not* ignore hidden.
+
+
+@end
+
+

--- a/MGSSyntaxErrors.h
+++ b/MGSSyntaxErrors.h
@@ -1,0 +1,49 @@
+//
+//  MGSSyntaxErrors.h
+//  Fragaria
+//
+//  Created by Jim Derry on 2/14/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "MGSSyntaxErrorProtocols.h"
+
+/**
+ *  MGSSyntaxErrors implements the <MGSSyntaxErrors> protocol for Fragaria.
+ *  Refer to the protocol header or documentation for a description of the
+ *  methods and properties implemented here.
+ **/
+
+@interface MGSSyntaxErrors : NSObject <MGSSyntaxErrors>
+
+/// @name Instance Methods - Instantiaton
+
+- (instancetype)initWithErrorsFromArray:(NSArray *)errors;
+
+
+/// @name Instance Methods - Setting and clearing errors
+
+- (void)addErrorFromDictionary:(NSDictionary*)error;       
+
+- (void)addError:(id<MGSSyntaxError>)error;                
+
+
+/// @name Instance Methods - Accessing error data
+
+- (NSArray *)linesWithErrors;
+
+- (NSUInteger)errorCountForLine:(NSInteger)line;
+
+- (id<MGSSyntaxError>)errorForLine:(NSInteger)line;
+
+- (NSArray*)errorsForLine:(NSInteger)line;                       
+
+- (NSArray *)nonHiddenErrors;
+
+
+/// @name Properties
+
+@property (nonatomic, strong) NSArray* syntaxErrors;
+
+@end

--- a/MGSSyntaxErrors.m
+++ b/MGSSyntaxErrors.m
@@ -1,0 +1,108 @@
+//
+//  MGSSyntaxErrors.m
+//  Fragaria
+//
+//  Created by Jim Derry on 2/14/15.
+//
+//
+
+
+#import "MGSSyntaxErrors.h"
+#import "SMLSyntaxError.h"
+
+
+@implementation MGSSyntaxErrors
+
+@synthesize syntaxErrors = _syntaxErrors;
+
+#pragma mark - Instance Methods - Instantiation
+
+
+- (instancetype)initWithErrorsFromArray:(NSArray *)errors
+{
+    if ((self = [super init]))
+    {
+        self.syntaxErrors = errors;
+    }
+    return self;
+}
+
+
+#pragma mark - Setting and clearing errors
+
+
+- (void)addErrorFromDictionary:(NSDictionary*)error
+{
+    [self addError:[SMLSyntaxError errorWithDictionary:error]];
+}
+
+
+- (void)addError:(id<MGSSyntaxError>)error
+{
+    if (self.syntaxErrors)
+    {
+        self.syntaxErrors = [self.syntaxErrors arrayByAddingObject:error];
+    }
+    else
+    {
+        self.syntaxErrors = [NSArray arrayWithObject:error];
+    }
+}
+
+
+#pragma mark - Accessing error data
+
+- (NSArray *)linesWithErrors
+{
+    return [[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"hidden == %@", @(NO)]] valueForKeyPath:@"@distinctUnionOfObjects.line"];
+
+}
+
+
+- (NSUInteger)errorCountForLine:(NSInteger)line
+{
+    NSUInteger result = [[[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hidden == %@)", @(line), @(NO)]] valueForKeyPath:@"@count"] integerValue];
+    NSLog(@"%lu", (unsigned long)result);
+    return [[[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hidden == %@)", @(line), @(NO)]] valueForKeyPath:@"@count"] integerValue];
+}
+
+
+- (id<MGSSyntaxError>)errorForLine:(NSInteger)line
+{
+    MGSSyntaxErrorType highestErrorLevel = [[[self errorsForLine:line] valueForKeyPath:@"@max.warningStyle"] integerValue];
+    NSArray* errors = [[self errorsForLine:line] filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"warningStyle = %@", @(highestErrorLevel)]];
+
+    return errors.firstObject;
+}
+
+
+- (NSArray*)errorsForLine:(NSInteger)line
+{
+    return [self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hidden == %@)", @(line), @(NO)]];
+}
+
+
+- (NSArray *)nonHiddenErrors
+{
+    return [self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"hidden == %@", @(NO)]];
+}
+
+
+#pragma mark - Properties
+
+
+- (void)setSyntaxErrors:(NSArray *)syntaxErrors
+{
+    NSPredicate *filter = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+        return [evaluatedObject conformsToProtocol:@protocol(MGSSyntaxError)];
+    }];
+    _syntaxErrors = [syntaxErrors filteredArrayUsingPredicate:filter];
+}
+
+- (NSArray *)syntaxErrors
+{
+    return _syntaxErrors;
+}
+
+
+@end

--- a/SMLSyntaxColouring.h
+++ b/SMLSyntaxColouring.h
@@ -39,7 +39,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 	BOOL reactToChanges;
 	BOOL syntaxErrorsAreDirty;
     
-    NSArray *syntaxErrors;
+    //id <MGSSyntaxErrors> syntaxErrors; // This is synthesized and there's a property.
     
     MGSSyntaxDefinition *syntaxDefinition;
     
@@ -52,7 +52,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 @property BOOL reactToChanges;
 @property (strong) NSUndoManager *undoManager;
-@property (nonatomic, strong) NSArray* syntaxErrors;
+@property (nonatomic, strong) id <MGSSyntaxErrors> syntaxErrors;
 @property (strong) MGSSyntaxDefinition *syntaxDefinition;
 
 - (id)initWithDocument:(id)document;

--- a/SMLSyntaxColouring.m
+++ b/SMLSyntaxColouring.m
@@ -1482,12 +1482,12 @@ NSString *SMLSyntaxGroupSecondStringPass2 = @"secondStringPass2";
         [button removeFromSuperview];
     }
     
-    if (!syntaxErrors) return;
+    if (!syntaxErrors.syntaxErrors) return;
     
     // Highlight all errors and add buttons
     NSMutableSet* highlightedRows = [NSMutableSet set];
 
-    for (SMLSyntaxError* err in syntaxErrors)
+    for (id <MGSSyntaxError> err in syntaxErrors.syntaxErrors)
     {
         // Highlight an erronous line
         NSInteger location = [self characterIndexFromLine:err.line character:err.character inString:text];
@@ -1503,28 +1503,22 @@ NSString *SMLSyntaxGroupSecondStringPass2 = @"secondStringPass2";
             // Remember that we are highlighting this row
             [highlightedRows addObject:[NSNumber numberWithInt:err.line]];
             
-            // Add highlight for background
-            if (!err.customBackgroundColor) {
-                [layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:[NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1] forCharacterRange:lineRange];
-            } else {
-                [layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:err.customBackgroundColor forCharacterRange:lineRange];
-            }
+            // Add syntax error highlight for background
+            [layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:err.errorLineHighlightColor forCharacterRange:lineRange];
             
             if ([err.description length] > 0)
                 [layoutManager addTemporaryAttribute:NSToolTipAttributeName value:err.description forCharacterRange:lineRange];
 
             if ([[document valueForKey:MGSFOShowsWarningsInEditor] boolValue]) {
 
-                // err.hideWarning is per-error, and there may be multiple errors per line. We only
-                // arrive here once per line, so we have to check whether there are _any_ errors on
-                // this line, not just the current err.
-                NSInteger countOfNonHiddenWarnings = [[[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hideWarning == %@)", @(err.line), @(NO)]] valueForKeyPath:@"@count"] integerValue];
-
-                if (countOfNonHiddenWarnings) {
+                // err.hidden is per-error, and there may be multiple errors per line. We only arrive here once per
+                // line, so we have to check whether there are _any_ errors on this line, not just the current err.
+                if ([syntaxErrors errorCountForLine:err.line] > 0) {
                     NSInteger glyphIndex = [layoutManager glyphIndexForCharacterAtIndex:lineRange.location];
                     
                     NSRect linePos = [layoutManager boundingRectForGlyphRange:NSMakeRange(glyphIndex, 1) inTextContainer:[textView textContainer]];
-                    
+
+                    // @todo: migrate all of this into the error provider.
                     // Add button
                     NSButton* warningButton = [[NSButton alloc] init];
                     
@@ -1537,11 +1531,9 @@ NSString *SMLSyntaxGroupSecondStringPass2 = @"secondStringPass2";
                     [warningButton setAction:@selector(pressedWarningBtn:)];
                     [warningButton setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-                    // Note that's only highlighting this row once, so there's only one opportunity
-                    // to set an error image. Let's choose the highest level of error if there are
-                    // multiple errors for this line.
-                    MGSErrorType style = [[[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hideWarning == %@)", @(err.line), @(NO)]] valueForKeyPath:@"@max.warningStyle"] integerValue];
-                    NSImage *warnImg = [SMLSyntaxError imageForWarningStyle:style];
+                    // We only arrive here once per line, so let's choose the highest level of error if
+                    // there are multiple errors for this line.
+                    NSImage *warnImg = [[syntaxErrors errorForLine:err.line] warningImage];
                     [warnImg setSize:NSMakeSize(linePos.size.height,linePos.size.height)];
                     [warningButton setImage:warnImg];
                     [textView addSubview:warningButton];
@@ -1570,7 +1562,7 @@ NSString *SMLSyntaxGroupSecondStringPass2 = @"secondStringPass2";
     // @todo: currently shows hidden errors. Should prevent that.
     // Fetch errors to display
     NSMutableArray* errorsOnLine = [NSMutableArray array];
-    for (SMLSyntaxError* err in syntaxErrors)
+    for (id <MGSSyntaxError> err in self.syntaxErrors.syntaxErrors)
     {
         if (err.line == line)
         {

--- a/SMLSyntaxError.h
+++ b/SMLSyntaxError.h
@@ -7,41 +7,35 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "MGSSyntaxErrorProtocols.h"
 
-typedef enum : NSInteger
-{
-    kMGSErrorDefault  = 0,
-    kMGSErrorAccess   = 1,
-    kMGSErrorConfig   = 2,
-    kMGSErrorDocument = 3,
-    kMGSErrorInfo     = 4,
-    kMGSErrorWarning  = 5,
-    kMGSErrorError    = 6,
-    kMGSErrorPanic    = 7
-} MGSErrorType;
+/**
+ *  SMLSyntax error implements the <MGSSyntaxError> protocol for Fragaria.
+ *  Refer to the protocol header or documentation for a description of the
+ *  methods and properties implemented here.
+ **/
+@interface SMLSyntaxError : NSObject <MGSSyntaxError>
 
-@interface SMLSyntaxError : NSObject
-{
-    NSString* description;
-    int line;
-    int character;
-    NSString* code;
-    int length;
-    BOOL hideWarning;
-    NSColor *customBackgroundColor;
-    MGSErrorType warningStyle;
-}
+/// @name Methods to implement for <MGSSyntaxError>
 
-+ (NSImage *)imageForWarningStyle:(MGSErrorType)style;
++ (instancetype) errorWithDictionary:(NSDictionary *)dictionary;
 
-@property (nonatomic,copy) NSString* description;
++ (NSImage *)imageForWarningStyle:(MGSSyntaxErrorType)style;
+
+- (instancetype)initWithDictionary:(NSDictionary *)errorDict;
+
+/// @name Properties for <MGSSyntaxError>
+
 @property (nonatomic,assign) int line;
 @property (nonatomic,assign) int character;
-@property (nonatomic,copy) NSString* code;
 @property (nonatomic,assign) int length;
-@property (nonatomic,assign) BOOL hideWarning;
-@property (nonatomic,copy) NSColor *customBackgroundColor;
-@property (nonatomic,assign) MGSErrorType warningStyle;
+@property (nonatomic,copy) NSString* description;
+@property (nonatomic,copy) NSString* code;
+@property (nonatomic,assign) BOOL hidden;
+@property (nonatomic,copy) NSColor *errorLineHighlightColor;
+@property (nonatomic,copy) NSColor *errorBackgroundHighlightColor;
+@property (nonatomic,copy) NSColor *errorForegroundHilightColor;
+@property (nonatomic,assign) MGSSyntaxErrorType warningStyle;
 @property (nonatomic,readonly) NSImage *warningImage;
 
 @end

--- a/SMLSyntaxError.m
+++ b/SMLSyntaxError.m
@@ -10,22 +10,59 @@
 
 @implementation SMLSyntaxError
 
-@synthesize line, character, code, length, description, hideWarning, customBackgroundColor, warningStyle;
-
+@synthesize line, character, length, description, code, hidden, warningStyle;
+@synthesize errorLineHighlightColor = _errorLineHighlightColor;
+@synthesize errorBackgroundHighlightColor = _errorBackgroundHighlightColor; // @todo: not yet implemented.
+@synthesize errorForegroundHilightColor = _errorForegroundHilightColor;     // @todo: not yet implemented.
 
 #pragma mark - Class Methods
 
-+ (NSImage *)imageForWarningStyle:(MGSErrorType)style
++ (instancetype) errorWithDictionary:(NSDictionary *)dictionary;
+{
+    return [[[self class] alloc] initWithDictionary:dictionary];
+}
+
++ (NSImage *)imageForWarningStyle:(MGSSyntaxErrorType)style
 {
     // Note these are in order by MGSErrorType.
-    NSArray *imageNames = @[@"messagesWarning", @"messagesAccess", @"messagesConfig", @"messagesDocument", @"messagesInfo", @"messagesWarning",@"messagesError", @"messagesPanic"];
+    NSArray *imageNames = @[@"messagesWarning", @"messagesAccess", @"messagesConfig", @"messagesDocument", @"messagesInfo", @"messagesWarning", @"messagesError", @"messagesPanic"];
     NSImage *warningImage = [[NSBundle bundleForClass:[self class]] imageForResource:imageNames[style]];
     [warningImage setSize:NSMakeSize(16.0, 16.0)];
     return warningImage;
 }
 
 
+#pragma mark - Instance Methods
+
+- (instancetype)initWithDictionary:(NSDictionary *)errorDict
+{
+    if ((self = [super init]))
+    {
+        [self setValuesForKeysWithDictionary:errorDict];
+    }
+    return self;
+}
+
+
 #pragma mark - Property Accessors
+
+- (void)setErrorLineHighlightColor:(NSColor *)errorLineHighlightColor
+{
+    _errorLineHighlightColor = errorLineHighlightColor;
+}
+
+- (NSColor*)errorLineHighlightColor
+{
+    if (_errorLineHighlightColor)
+    {
+        return _errorLineHighlightColor;
+    }
+    else
+    {
+        return [NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1];
+    }
+}
+
 
 - (NSImage *)warningImage
 {


### PR DESCRIPTION
This is another big one due to the internal changes, slight that they may be.

With an eye toward @7 and @10:
- Defined the <MGSSyntaxError> and <MGSSyntaxError> protocols.
- SMLSyntaxError now conforms to <MGSSyntaxError>.
- SMLSyntaxError has a convenience methods added to it to make error creation easier.
- The new MGSSyntaxErrors implements <MGSSyntaxErrors>.
- It's vastly incomplete, but implements convenience methods for adding to the errors array, and other convenience methods that clean up the code that's implementing them (e.g., all of the predicate stuff that was being used.)
- Updated the rest of Fragaria and its components to use the error classes anonymously via the protocols.
- Renamed some of the properties more inline with Apple conventions (e.g., hidden).
- Background color is no longer optional, although the default is to use the same color as from SMLSyntaxColouring.m. This simplified SMLSyntaxColouring, too.

It's woefully incomplete, but it's late. What I plan to add if this isn't abandoned is:
- Return the NSButton that's needed.
- Manage the button actions in order to get them out of the ruler and text views.
- Go back and double check that all the int types are reasonable.

This is an external API change unfortunately, although it's very, very minor:
- Instead of assigning an array of error objects to FragariaInstance.syntaxErrors, direct assignment goes to FragariaInstance.syntaxErrors.syntaxErrors. However with the new methods, it's not really necessary to create an array of errors and make the assignment any more.
- The renamed properties seem minor to me, too.

I hate to break an external API, but I think this fork is already not a drop-in replacement for the original.

(Most of it is well-documented in AppleDoc format. Honestly that took 90% of the time for this code!)
