### PR TITLE
Improve errors

### DIFF
--- a/Applications/MGSFragariaView/AppDelegate.m
+++ b/Applications/MGSFragariaView/AppDelegate.m
@@ -75,7 +75,7 @@
 
 
 	/* Sample Syntax Error Definitions */
-    //self.viewTop.syntaxErrors = [self makeSyntaxErrors];
+    self.viewTop.syntaxErrors = [self makeSyntaxErrors];
 
 
 
@@ -186,42 +186,40 @@
  *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
 - (NSArray *)makeSyntaxErrors
 {
-    SMLSyntaxError *syntaxError = [SMLSyntaxError new];
-    syntaxError.description = @"Syntax errors can be defined";
-    syntaxError.line = 4;
-    syntaxError.character = 3;
-    syntaxError.length = 5;
-    syntaxError.hideWarning = YES;
-    syntaxError.warningStyle = kMGSErrorError;
-    //syntaxError.customBackgroundColor = [NSColor magentaColor];
+    SMLSyntaxError *error1 = [SMLSyntaxError errorWithDictionary:@{
+                                                                   @"description" : @"Syntax errors can be defined",
+                                                                   @"line" : @(4),
+                                                                   @"character" : @(3),
+                                                                   @"length" : @(5),
+                                                                   @"hidden" : @(YES),
+                                                                   @"warningLevel" : @(kMGSErrorError)
+                                                                   }];
 
-    SMLSyntaxError *syntaxError2 = [SMLSyntaxError new];
-    syntaxError2.description = @"Multiple syntax errors can be defined for the same line, too.";
-    syntaxError2.line = 4;
-    syntaxError2.character = 12;
-    syntaxError2.length = 7;
-    syntaxError2.hideWarning = NO;
-    syntaxError2.warningStyle = kMGSErrorAccess;
-    //syntaxError2.customBackgroundColor = syntaxError.customBackgroundColor; // messy coloring if you use different colors on the same line!
+    SMLSyntaxError *error2 = [[SMLSyntaxError alloc] initWithDictionary:@{
+                                                                          @"description" : @"Multiple syntax errors can be defined for the same line, too.",
+                                                                          @"line" : @(4),
+                                                                          @"character" : @(12),
+                                                                          @"length" : @(7),
+                                                                          @"hidden" : @(NO),
+                                                                          @"warningLevel" : @(kMGSErrorAccess)
+                                                                          }];
 
-    SMLSyntaxError *syntaxError3 = [SMLSyntaxError new];
-    syntaxError3.description = @"This error will appear on top of a line break.";
-    syntaxError3.line = 6;
-    syntaxError3.character = 1;
-    syntaxError3.length = 2;
-    syntaxError3.hideWarning = NO;
-    syntaxError3.warningStyle = kMGSErrorConfig;
-    //syntaxError2.customBackgroundColor = syntaxError.customBackgroundColor; // messy coloring if you use different colors on the same line!
+    SMLSyntaxError *error3 = [[SMLSyntaxError alloc] init];
+    error3.description = @"This error will appear on top of a line break.";
+    error3.line = 6;
+    error3.character = 1;
+    error3.length = 2;
+    error3.hideWarning = NO;
+    error3.warningStyle = kMGSErrorConfig;
 
-    SMLSyntaxError *syntaxError4 = [SMLSyntaxError new];
-    syntaxError4.description = @"This error will be hidden.";
-    syntaxError4.line = 10;
-    syntaxError4.character = 12;
-    syntaxError4.length = 7;
-    syntaxError4.hideWarning = NO;
-    //syntaxError2.customBackgroundColor = syntaxError.customBackgroundColor; // messy coloring if you use different colors on the same line!
+    SMLSyntaxError *error4 = [SMLSyntaxError new];
+    error4.description = @"This error will be hidden.";
+    error4.line = 10;
+    error4.character = 12;
+    error4.length = 7;
+    error4.hideWarning = NO;
 
-    return @[syntaxError, syntaxError2, syntaxError3, syntaxError4];
+    return @[error1, error2, error3, error4];
 }
 
 @end

--- a/Fragaria.xcodeproj/project.pbxproj
+++ b/Fragaria.xcodeproj/project.pbxproj
@@ -249,10 +249,10 @@
 		D0C145C21A85E1FD00DDE90A /* SMLTextView+MGSDragging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SMLTextView+MGSDragging.h"; sourceTree = "<group>"; };
 		D0C145C31A85E1FD00DDE90A /* SMLTextView+MGSDragging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SMLTextView+MGSDragging.m"; sourceTree = "<group>"; };
 		D0C1464C1A87196200DDE90A /* MGSFragariaView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MGSFragariaView.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D0C1464F1A87196200DDE90A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Applications/MGSFragariaView/Info.plist; sourceTree = "<group>"; };
-		D0C146501A87196200DDE90A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = ../Applications/MGSFragariaView/AppDelegate.h; sourceTree = "<group>"; };
-		D0C146511A87196200DDE90A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = ../Applications/MGSFragariaView/AppDelegate.m; sourceTree = "<group>"; };
-		D0C146531A87196200DDE90A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ../Applications/MGSFragariaView/main.m; sourceTree = "<group>"; };
+		D0C1464F1A87196200DDE90A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Applications/MGSFragariaView/Info.plist; sourceTree = "<group>"; };
+		D0C146501A87196200DDE90A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = Applications/MGSFragariaView/AppDelegate.h; sourceTree = "<group>"; };
+		D0C146511A87196200DDE90A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = Applications/MGSFragariaView/AppDelegate.m; sourceTree = "<group>"; };
+		D0C146531A87196200DDE90A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Applications/MGSFragariaView/main.m; sourceTree = "<group>"; };
 		D0C146581A87196200DDE90A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		D0C146731A871A0B00DDE90A /* MGSFragariaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSFragariaView.h; sourceTree = "<group>"; };
 		D0C146741A871A0B00DDE90A /* MGSFragariaView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSFragariaView.m; sourceTree = "<group>"; };
@@ -578,7 +578,7 @@
 				01BB1BF21A79AA15006C0056 /* MGSSimpleBreakpointDelegate.m */,
 				AB648E2311FB37D200AEF7BD /* NSDocument based */,
 				AB648E2211FB37AF00AEF7BD /* Simple */,
-				D0C1464D1A87196200DDE90A /* MGSFragariaView */,
+				D0E521001A90B899005CB80B /* MGSFragariaView */,
 			);
 			name = Applications;
 			sourceTree = "<group>";
@@ -606,19 +606,19 @@
 			name = Fragaria;
 			sourceTree = "<group>";
 		};
-		D0C1464D1A87196200DDE90A /* MGSFragariaView */ = {
+		D0E521001A90B899005CB80B /* MGSFragariaView */ = {
 			isa = PBXGroup;
 			children = (
 				D0C146501A87196200DDE90A /* AppDelegate.h */,
 				D0C146511A87196200DDE90A /* AppDelegate.m */,
 				D0C146571A87196200DDE90A /* MainMenu.xib */,
 				D0C146771A871AF300DDE90A /* Lorem.html */,
-				D0C1464E1A87196200DDE90A /* Supporting Files */,
+				D0E521011A90B8B7005CB80B /* Supporting Files */,
 			);
-			path = MGSFragariaView;
+			name = MGSFragariaView;
 			sourceTree = "<group>";
 		};
-		D0C1464E1A87196200DDE90A /* Supporting Files */ = {
+		D0E521011A90B8B7005CB80B /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
 				D0C1464F1A87196200DDE90A /* Info.plist */,
@@ -973,7 +973,7 @@
 				D0C146581A87196200DDE90A /* Base */,
 			);
 			name = MainMenu.xib;
-			path = ../Applications/MGSFragariaView;
+			path = Applications/MGSFragariaView;
 			sourceTree = "<group>";
 		};
 		D0C146771A871AF300DDE90A /* Lorem.html */ = {
@@ -982,7 +982,7 @@
 				D0C146781A871AF300DDE90A /* Base */,
 			);
 			name = Lorem.html;
-			path = ../Applications/MGSFragariaView;
+			path = Applications/MGSFragariaView;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/Fragaria.xcodeproj/project.pbxproj
+++ b/Fragaria.xcodeproj/project.pbxproj
@@ -390,7 +390,6 @@
 				AB6C86C2160FA2B500488AF2 /* MGSGlyphGenerator.m */,
 				013278651A81610E00D2DCA5 /* Syntax Definition Manager */,
 				01BB1BEE1A7964DC006C0056 /* Gutter Text View */,
-				AB69B659118B75E100903D1D /* Error Popover */,
 			);
 			name = "Text View Components";
 			sourceTree = "<group>";
@@ -539,15 +538,6 @@
 			name = "NSDocument based";
 			sourceTree = "<group>";
 		};
-		AB69B659118B75E100903D1D /* Error Popover */ = {
-			isa = PBXGroup;
-			children = (
-				E3C1850117175ED900801FE5 /* SMLErrorPopOver.h */,
-				E3C1850217175ED900801FE5 /* SMLErrorPopOver.m */,
-			);
-			name = "Error Popover";
-			sourceTree = "<group>";
-		};
 		AB69B752118B82DF00903D1D /* Framework */ = {
 			isa = PBXGroup;
 			children = (
@@ -595,10 +585,9 @@
 				D0C146741A871A0B00DDE90A /* MGSFragariaView.m */,
 				AB69B753118B830700903D1D /* MGSFragaria.h */,
 				AB41C1041191FFCB004F0CB5 /* MGSFragaria.m */,
-				E3D4B2751714D89700BB2CC6 /* SMLSyntaxError.h */,
-				E3D4B2761714D89700BB2CC6 /* SMLSyntaxError.m */,
 				0191FA831A882B0F0099B50D /* Global Private Headers */,
 				AB83887D171E94C5004408F4 /* NS Categories */,
+				D0E521021A90BAC1005CB80B /* Syntax Error Components */,
 				01BB1BEC1A7962C7006C0056 /* Text View Components */,
 				01BB1BEB1A79620E006C0056 /* Text Editing UI */,
 				01BB1BEA1A795EFD006C0056 /* Preferences */,
@@ -625,6 +614,17 @@
 				D0C146531A87196200DDE90A /* main.m */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		D0E521021A90BAC1005CB80B /* Syntax Error Components */ = {
+			isa = PBXGroup;
+			children = (
+				E3D4B2751714D89700BB2CC6 /* SMLSyntaxError.h */,
+				E3D4B2761714D89700BB2CC6 /* SMLSyntaxError.m */,
+				E3C1850117175ED900801FE5 /* SMLErrorPopOver.h */,
+				E3C1850217175ED900801FE5 /* SMLErrorPopOver.m */,
+			);
+			name = "Syntax Error Components";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/MGSLineNumberView.m
+++ b/MGSLineNumberView.m
@@ -647,6 +647,8 @@
     // There may be multiple errors for this line, so find the one with the highest warningStyle.
     MGSErrorType style = [[[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hideWarning == %@)", line, @(NO)]] valueForKeyPath:@"@max.warningStyle"] integerValue];
     [warningButton setImage:[SMLSyntaxError imageForWarningStyle:style]];
+    [[warningButton image] setSize:NSMakeSize(16.0, 16.0)];
+
 
     [self addSubview:warningButton];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-4-[warningButton]" options:0 metrics:nil views:NSDictionaryOfVariableBindings(warningButton)]];

--- a/SMLSyntaxColouring.m
+++ b/SMLSyntaxColouring.m
@@ -1466,11 +1466,7 @@ NSString *SMLSyntaxGroupSecondStringPass2 = @"secondStringPass2";
             [highlightedRows addObject:[NSNumber numberWithInt:err.line]];
             
             // Add highlight for background
-            if (!err.customBackgroundColor) {
-                [layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:[NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1] forCharacterRange:lineRange];
-            } else {
-                [layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:err.customBackgroundColor forCharacterRange:lineRange];
-            }
+            [layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:err.errorLineHighlightColor forCharacterRange:lineRange];
             
             if ([err.description length] > 0)
                 [layoutManager addTemporaryAttribute:NSToolTipAttributeName value:err.description forCharacterRange:lineRange];

--- a/SMLSyntaxError.h
+++ b/SMLSyntaxError.h
@@ -6,9 +6,19 @@
 //
 //
 
+
 #import <Foundation/Foundation.h>
 
-typedef enum : NSInteger
+/**
+ *  MGSErrorType describes the warning level for an error, ranging from least severe to most severe.
+ *  This can be used to automatically provide an appropriate image for error displays.
+ *
+ *  @discussion Components using this class are not currently KVO compliant and do not observe changes
+ *  to instances of this class. They expect an NSArray of this class for which they will respond to
+ *  changes. Do not modify instances of this class once assigned to your instance of Fragaria; instead
+ *  assign a new copy of your syntaxErrors array.
+ **/
+typedef NS_ENUM(NSInteger, MGSErrorType)
 {
     kMGSErrorDefault  = 0,
     kMGSErrorAccess   = 1,
@@ -18,30 +28,74 @@ typedef enum : NSInteger
     kMGSErrorWarning  = 5,
     kMGSErrorError    = 6,
     kMGSErrorPanic    = 7
-} MGSErrorType;
+};
+
+
+/**
+ *  SMLSyntaxError describes a class that stores syntaxErrors to be handled by Fragaria.
+ **/
 
 @interface SMLSyntaxError : NSObject
-{
-    NSString* description;
-    int line;
-    int character;
-    NSString* code;
-    int length;
-    BOOL hideWarning;
-    NSColor *customBackgroundColor;
-    MGSErrorType warningStyle;
-}
 
-+ (NSImage *)imageForWarningStyle:(MGSErrorType)style;
 
-@property (nonatomic,copy) NSString* description;
-@property (nonatomic,assign) int line;
-@property (nonatomic,assign) int character;
-@property (nonatomic,copy) NSString* code;
-@property (nonatomic,assign) int length;
-@property (nonatomic,assign) BOOL hideWarning;
-@property (nonatomic,copy) NSColor *customBackgroundColor;
-@property (nonatomic,assign) MGSErrorType warningStyle;
-@property (nonatomic,readonly) NSImage *warningImage;
+/// @name Class Methods
+
+/**
+ *  This class method will return an image that represents the property `warningLevel`.
+ *  The default images are stored in and loaded from the framework bundle automatically.
+ *  @param level indicates the level of this error.
+ **/
++ (NSImage *)defaultImageForWarningLevel:(MGSErrorType)level;
+
+
+/**
+ *  This class method is a synonym for imageForWarningLevel.
+ *  @deprecated Use defaultImageForWarningLevel: instead.
+ *  @param style indicates the level of this error.
+ **/
++ (NSImage *)imageForWarningStyle:(MGSErrorType)style __deprecated_msg("Use defaultImageForWarningLevel: instead.");
+
+
+/// @name Properties
+
+@property (nonatomic,assign) int line;                             ///< The line at which this error occurrs.
+@property (nonatomic,assign) int character;                        ///< The character position at which this error begins.
+@property (nonatomic,assign) int length;                           ///< The character length of this error.
+@property (nonatomic,copy) NSString* description;                  ///< A description of this error.
+@property (nonatomic,assign) BOOL hidden;                          ///< Indicates whether or not this error is hidden from display.
+
+@property (nonatomic,copy) NSColor *errorLineHighlightColor;       ///< The color to use to highlight lines that have syntax errors.
+@property (nonatomic,copy) NSColor *errorBackgroundHighlightColor; ///< The color to use to highlight the background of specific errors.
+@property (nonatomic,copy) NSColor *errorForegroundHilightColor;   ///< The color to use to highlight the foreground of specific errors.
+@property (nonatomic,assign) MGSErrorType warningLevel;            ///< The warning level or severity of this syntax error.
+
+/**
+ *  Specifies an image that should be associated with this syntax error.
+ *  @discussion By default this property will return one of the built-in
+ *  images that represent the warningLevel. However you can assign your
+ *  own image to this property regardless of warningLevel. This property
+ *  cannot be nil. Attempts to set it to nil will revert it to the
+ *  built-in default.
+ **/
+@property (nonatomic,strong) NSImage *warningImage;
+
+
+/**
+ * @name Deprecated Properties
+ * @todo AppleDoc currently chokes on these; it doesn't like the attributes.
+ **/
+
+/// @deprecated This property is not used.
+@property (nonatomic,copy) NSString* code __deprecated_msg("This property is not used.");
+
+/// @deprecated Use the warningLevel property instead.
+@property (nonatomic,assign) MGSErrorType warningStyle;// __deprecated_msg("Use the warningLevel property instead.");
+
+/// @deprecated Use the hidden property instead.
+@property (nonatomic,assign) BOOL hideWarning __deprecated_msg("Use the hidden property instead.");
+
+/// @deprecated Use the errorLineHighlightColor property.
+@property (nonatomic,copy) NSColor *customBackgroundColor __deprecated_msg("Use the errorLineHighlightColor property.");
+
 
 @end

--- a/SMLSyntaxError.h
+++ b/SMLSyntaxError.h
@@ -49,6 +49,24 @@ typedef NS_ENUM(NSInteger, MGSErrorType)
 
 
 /**
+ *  This class method is a convenience for creating new SMLSyntaxError instances.
+ *  @param dictionary indicates a dictionary where each key is the property name.
+ **/
++ (instancetype)errorWithDictionary:(NSDictionary *)dictionary;
+
+
+/// @name Instance Methods
+
+/**
+ *  This initializer receives a dictionary of keys and values, where the dictionary
+ *  keys correspond to property names of this class.
+ *  @param dictionary indicates the dictionary from which to initialize this class.
+ **/
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
+
+/// @name Deprecated Class Methods
+
+/**
  *  This class method is a synonym for imageForWarningLevel.
  *  @deprecated Use defaultImageForWarningLevel: instead.
  *  @param style indicates the level of this error.
@@ -89,7 +107,7 @@ typedef NS_ENUM(NSInteger, MGSErrorType)
 @property (nonatomic,copy) NSString* code __deprecated_msg("This property is not used.");
 
 /// @deprecated Use the warningLevel property instead.
-@property (nonatomic,assign) MGSErrorType warningStyle;// __deprecated_msg("Use the warningLevel property instead.");
+@property (nonatomic,assign) MGSErrorType warningStyle __deprecated_msg("Use the warningLevel property instead.");
 
 /// @deprecated Use the hidden property instead.
 @property (nonatomic,assign) BOOL hideWarning __deprecated_msg("Use the hidden property instead.");

--- a/SMLSyntaxError.m
+++ b/SMLSyntaxError.m
@@ -32,6 +32,26 @@
     return warningImage;
 }
 
++ (instancetype) errorWithDictionary:(NSDictionary *)dictionary
+{
+    return [[[self class] alloc] initWithDictionary:dictionary];
+}
+
+
+#pragma mark - Instance Methods
+
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
+{
+    if ((self = [super init]))
+    {
+        [self setValuesForKeysWithDictionary:dictionary];
+    }
+    return self;
+}
+
+
+#pragma mark - Deprecated Class Methods
+
 
 + (NSImage *)imageForWarningStyle:(MGSErrorType)style
 {
@@ -98,7 +118,7 @@
 {
     if (!_warningImage)
     {
-        _warningImage = [[self class] defaultImageForWarningLevel:self.warningStyle];
+        _warningImage = [[self class] defaultImageForWarningLevel:self.warningLevel];
     }
 
     return _warningImage;
@@ -132,12 +152,12 @@
 
 -(void)setCustomBackgroundColor:(NSColor *)customBackgroundColor
 {
-    self.errorBackgroundHighlightColor = customBackgroundColor;
+    self.errorLineHighlightColor = customBackgroundColor;
 }
 
 - (NSColor *)customBackgroundColor
 {
-    return self.errorBackgroundHighlightColor;
+    return self.errorLineHighlightColor;
 }
 
 @end

--- a/SMLSyntaxError.m
+++ b/SMLSyntaxError.m
@@ -10,26 +10,134 @@
 
 @implementation SMLSyntaxError
 
-@synthesize line, character, code, length, description, hideWarning, customBackgroundColor, warningStyle;
+// automatic
+@synthesize line, character, length, description, hidden, warningLevel;
 
+// manual
+@synthesize errorLineHighlightColor = _errorLineHighlightColor;
+@synthesize errorBackgroundHighlightColor = _errorBackgroundHighlightColor;
+@synthesize errorForegroundHilightColor = _errorForegroundHilightColor;
+@synthesize warningImage = _warningImage;
+
+// to be deprecated
+@synthesize code; // deprecated; separate line as reminder to remove.
 
 #pragma mark - Class Methods
 
++ (NSImage *)defaultImageForWarningLevel:(MGSErrorType)level
+{
+    // Note these are in order by MGSErrorType. @todo: Bounds checking.
+    NSArray *imageNames = @[@"messagesWarning", @"messagesAccess", @"messagesConfig", @"messagesDocument", @"messagesInfo", @"messagesWarning",@"messagesError", @"messagesPanic"];
+    NSImage *warningImage = [[NSBundle bundleForClass:[self class]] imageForResource:imageNames[level]];
+    return warningImage;
+}
+
+
 + (NSImage *)imageForWarningStyle:(MGSErrorType)style
 {
-    // Note these are in order by MGSErrorType.
-    NSArray *imageNames = @[@"messagesWarning", @"messagesAccess", @"messagesConfig", @"messagesDocument", @"messagesInfo", @"messagesWarning",@"messagesError", @"messagesPanic"];
-    NSImage *warningImage = [[NSBundle bundleForClass:[self class]] imageForResource:imageNames[style]];
-    [warningImage setSize:NSMakeSize(16.0, 16.0)];
-    return warningImage;
+    return [[self class] defaultImageForWarningLevel:style];
 }
 
 
 #pragma mark - Property Accessors
 
+- (void)setErrorLineHighlightColor:(NSColor *)errorLineHighlightColor
+{
+    _errorLineHighlightColor = errorLineHighlightColor;
+}
+
+- (NSColor *)errorLineHighlightColor
+{
+    if (!_errorLineHighlightColor)
+    {
+        _errorLineHighlightColor = [NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1];
+    }
+
+    return _errorLineHighlightColor;
+}
+
+
+-(void)setErrorBackgroundHighlightColor:(NSColor *)errorBackgroundHighlightColor
+{
+    _errorBackgroundHighlightColor = errorBackgroundHighlightColor;
+}
+
+- (NSColor *)errorBackgroundHighlightColor
+{
+    if (!_errorBackgroundHighlightColor)
+    {
+        _errorBackgroundHighlightColor = [NSColor orangeColor];
+    }
+
+    return _errorBackgroundHighlightColor;
+}
+
+
+-(void)setErrorForegroundHilightColor:(NSColor *)errorForegroundHilightColor
+{
+    _errorForegroundHilightColor = errorForegroundHilightColor;
+}
+
+- (NSColor *)errorForegroundHilightColor
+{
+    if (!_errorForegroundHilightColor)
+    {
+        _errorForegroundHilightColor = [NSColor whiteColor];
+    }
+
+    return _errorForegroundHilightColor;
+}
+
+
+- (void)setWarningImage:(NSImage *)warningImage
+{
+    _warningImage = warningImage;
+}
+
 - (NSImage *)warningImage
 {
-    return [[self class] imageForWarningStyle:self.warningStyle];
+    if (!_warningImage)
+    {
+        _warningImage = [[self class] defaultImageForWarningLevel:self.warningStyle];
+    }
+
+    return _warningImage;
+}
+
+
+#pragma mark - Deprecated Properties
+
+
+- (void)setWarningStyle:(MGSErrorType)style
+{
+    self.warningLevel = style;
+}
+
+- (MGSErrorType)warningStyle
+{
+    return self.warningLevel;
+}
+
+
+- (void)setHideWarning:(BOOL)hideWarning
+{
+    self.hidden = hideWarning;
+}
+
+- (BOOL)hideWarning
+{
+    return self.hidden;
+}
+
+
+-(void)setCustomBackgroundColor:(NSColor *)customBackgroundColor
+{
+    self.errorBackgroundHighlightColor = customBackgroundColor;
+}
+
+- (NSColor *)customBackgroundColor
+{
+    return self.errorBackgroundHighlightColor;
 }
 
 @end


### PR DESCRIPTION
Okay, I'm taking this in smaller steps this time, including smaller, more logical commits. This change is small:
- Document SMLSyntaxError (although AppleDoc bug doesn't handle deprecated properties).
- Deprecated some of the properties/methods with warnings in order to implement properties/methods with better names. "Better" is subjective, of course. In any case no API change.
- Added a few convenience methods.
- Added two highlighting properties I hope to implement later in order to support the use of `character` and `length` properties to highlight the actual error(s) in addition to the error line.
- `customBackgroundColor` was deprecated in favor of `errorLineHighlightColor`, which now returns the default used in SMLSyntaxColoring. I'll replacing that existing logic in another PR (just an if/then). (possible that once I commit, Github will add it to this PR automatically).
- Did not updated any of the deprecations anywhere else in the code, so you will get a few annoying build warnings. (Demo, let's call it).

Edit:
- It should also be possible to specify a user warningImage now, too, with fallback for the built-in images.
