### PR TITLE
Breakpoint Delegate rework (part of improve errors)

### DIFF
--- a/Applications/MGSFragariaView/AppDelegate.h
+++ b/Applications/MGSFragariaView/AppDelegate.h
@@ -9,8 +9,10 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import "MGSBreakpointDelegate.h"
 
-@interface AppDelegate : NSObject <NSApplicationDelegate>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate, MGSBreakpointDelegate>
 
 @end
 

--- a/Applications/MGSFragariaView/AppDelegate.m
+++ b/Applications/MGSFragariaView/AppDelegate.m
@@ -218,7 +218,7 @@
                                                                    @"character" : @(3),
                                                                    @"length" : @(5),
                                                                    @"hidden" : @(YES),
-                                                                   @"warningLevel" : @(kMGSErrorError)
+                                                                   @"warningLevel" : @(kMGSErrorCategoryError)
                                                                    }];
 
     SMLSyntaxError *error2 = [[SMLSyntaxError alloc] initWithDictionary:@{
@@ -227,7 +227,7 @@
                                                                           @"character" : @(12),
                                                                           @"length" : @(7),
                                                                           @"hidden" : @(NO),
-                                                                          @"warningLevel" : @(kMGSErrorAccess)
+                                                                          @"warningLevel" : @(kMGSErrorCategoryAccess)
                                                                           }];
 
     SMLSyntaxError *error3 = [[SMLSyntaxError alloc] init];
@@ -236,10 +236,10 @@
     error3.character = 1;
     error3.length = 2;
     error3.hideWarning = NO;
-    error3.warningStyle = kMGSErrorConfig;
+    error3.warningStyle = kMGSErrorCategoryConfig;
 
     SMLSyntaxError *error4 = [SMLSyntaxError new];
-    error4.description = @"This error will be hidden.";
+    error4.description = @"This error will not be hidden.";
     error4.line = 10;
     error4.character = 12;
     error4.length = 7;

--- a/Applications/MGSFragariaView/AppDelegate.m
+++ b/Applications/MGSFragariaView/AppDelegate.m
@@ -102,21 +102,20 @@
 
 
 /*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	breakpointsForFile:
+	breakpointsForView:
  *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (NSSet*) breakpointsForFile:(NSString*)file
+- (NSSet*) breakpointsForView:(id)sender
 {
-	#pragma unused(file)
+	#pragma unused(sender)
     return [NSSet setWithArray:_breakPoints];
 }
 
 /*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	toggleBreakpointForFile:onLine
+	toggleBreakpointForView:onLine
  *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)toggleBreakpointForFile:(NSString*)file onLine:(int)line;
-
+- (void)toggleBreakpointForView:(id)sender onLine:(int)line;
 {
-	#pragma unused(file)
+	#pragma unused(sender)
 	if ([_breakPoints containsObject:@(line)])
 	{
 		_breakPoints = [_breakPoints filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {

--- a/Applications/MGSFragariaView/AppDelegate.m
+++ b/Applications/MGSFragariaView/AppDelegate.m
@@ -35,7 +35,9 @@
 #pragma mark - IMPLEMENTATION
 
 
-@implementation AppDelegate
+@implementation AppDelegate {
+	NSArray *_breakPoints;
+}
 
 
 #pragma mark - Initialization and Setup
@@ -105,9 +107,34 @@
 - (NSSet*) breakpointsForFile:(NSString*)file
 {
 	#pragma unused(file)
-	NSLog(@"%@", @"I'm the breakpoints delegate.");
-    //return [NSSet setWithArray:@[@(6)]];
-    return nil;
+    return [NSSet setWithArray:_breakPoints];
+}
+
+/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
+	toggleBreakpointForFile:onLine
+ *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
+- (void)toggleBreakpointForFile:(NSString*)file onLine:(int)line;
+
+{
+	#pragma unused(file)
+	if ([_breakPoints containsObject:@(line)])
+	{
+		_breakPoints = [_breakPoints filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+			return ![evaluatedObject isEqualToValue:@(line)];
+		}]];
+	}
+	else
+	{
+		if (_breakPoints)
+		{
+			_breakPoints = [_breakPoints arrayByAddingObject:@(line)];
+		}
+		else
+		{
+			_breakPoints = @[@(line)];
+		}
+	}
+	
 }
 
 

--- a/Fragaria.xcodeproj/project.pbxproj
+++ b/Fragaria.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		ABE25D0A1635CA7C00F23718 /* MGSFragariaPrefsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = ABE25D081635CA7C00F23718 /* MGSFragariaPrefsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ABE25D0B1635CA7C00F23718 /* MGSFragariaPrefsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ABE25D091635CA7C00F23718 /* MGSFragariaPrefsViewController.m */; };
 		ABF28AF014C075D400ECAD48 /* NSScanner+Fragaria.m in Sources */ = {isa = PBXBuildFile; fileRef = ABF28AEE14C075D400ECAD48 /* NSScanner+Fragaria.m */; };
+		D0AB50F01A91CDC200A6DF58 /* SMLSyntaxErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AB50EF1A91CDC200A6DF58 /* SMLSyntaxErrorTests.m */; };
 		D0C145C71A85F2C900DDE90A /* SMLTextView+MGSDragging.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C145C31A85E1FD00DDE90A /* SMLTextView+MGSDragging.m */; };
 		D0C146521A87196200DDE90A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C146511A87196200DDE90A /* AppDelegate.m */; };
 		D0C146541A87196200DDE90A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C146531A87196200DDE90A /* main.m */; };
@@ -257,6 +258,7 @@
 		ABE25D091635CA7C00F23718 /* MGSFragariaPrefsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSFragariaPrefsViewController.m; sourceTree = "<group>"; };
 		ABF28AEE14C075D400ECAD48 /* NSScanner+Fragaria.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = "NSScanner+Fragaria.m"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		ABF28AEF14C075D400ECAD48 /* NSScanner+Fragaria.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSScanner+Fragaria.h"; sourceTree = "<group>"; };
+		D0AB50EF1A91CDC200A6DF58 /* SMLSyntaxErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SMLSyntaxErrorTests.m; sourceTree = "<group>"; };
 		D0C145C21A85E1FD00DDE90A /* SMLTextView+MGSDragging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SMLTextView+MGSDragging.h"; sourceTree = "<group>"; };
 		D0C145C31A85E1FD00DDE90A /* SMLTextView+MGSDragging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SMLTextView+MGSDragging.m"; sourceTree = "<group>"; };
 		D0C1464C1A87196200DDE90A /* MGSFragariaView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MGSFragariaView.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -659,6 +661,7 @@
 			isa = PBXGroup;
 			children = (
 				D0E521071A90E307005CB80B /* MGSSyntaxErrorControllerTests.m */,
+				D0AB50EF1A91CDC200A6DF58 /* SMLSyntaxErrorTests.m */,
 				D0E5210F1A90E34F005CB80B /* Supporting Files */,
 			);
 			path = "MGSFragaria Tests";
@@ -999,6 +1002,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D0AB50F01A91CDC200A6DF58 /* SMLSyntaxErrorTests.m in Sources */,
 				D0E5211A1A90E399005CB80B /* MGSSyntaxErrorControllerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1655,6 +1659,7 @@
 				D0E521191A90E34F005CB80B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/MGSBreakpointDelegate.h
+++ b/MGSBreakpointDelegate.h
@@ -8,13 +8,42 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ *  The <MGSBreakpointDelegate> protocol specifies methods for delegates
+ *  to adopt in order to receive breakpoint-related messages from Fragaria.
+ **/
 @protocol MGSBreakpointDelegate <NSObject>
 
 
 @optional
 
-- (NSSet*) breakpointsForFile:(NSString*)file;
+/**
+ *  This message is sent to a delegate when Fragaria requests
+ *  a set of line numbers containing breakpoints.
+ *  @param sender The object sending the message, and is a reference to the Fragaria instance.
+ *  @return A set if NSNumber indicating the line numbers that have breakpoints.
+ **/
+- (NSSet*) breakpointsForView:(id)sender;
 
-- (void) toggleBreakpointForFile:(NSString*)file onLine:(int)line;
+
+/**
+ * This message is sent to a delegate when Fragaria indicates
+ * that a request to toggle a breakpoint was made.
+ * @param sender The object sending the message, and is a reference to the Fragaria instance.
+ @ @param line The line number for which the request was made.
+ **/
+- (void) toggleBreakpointForView:(id)sender onLine:(int)line;
+
+
+/**
+ *  @deprecated Use breakpointsForView: instead.
+ **/
+- (NSSet*) breakpointsForFile:(NSString*)file __deprecated_msg("Use breakpointsForView: instead.");
+
+
+/**
+ *  @deprecated Use toggleBreakpointForView:onLine: instead.
+ **/
+- (void) toggleBreakpointForFile:(NSString*)file onLine:(int)line __deprecated_msg("Use toggleBreakpointForView:onLine: instead.");
 
 @end

--- a/MGSBreakpointDelegate.h
+++ b/MGSBreakpointDelegate.h
@@ -10,7 +10,11 @@
 
 @protocol MGSBreakpointDelegate <NSObject>
 
-- (void) toggleBreakpointForFile:(NSString*)file onLine:(int)line;
+
+@optional
+
 - (NSSet*) breakpointsForFile:(NSString*)file;
+
+- (void) toggleBreakpointForFile:(NSString*)file onLine:(int)line;
 
 @end

--- a/MGSFragaria Tests/MGSSyntaxErrorControllerTests.m
+++ b/MGSFragaria Tests/MGSSyntaxErrorControllerTests.m
@@ -29,39 +29,39 @@
                                                                 @"description" : @"Sample error 1.",
                                                                 @"line" : @(4),
                                                                 @"hidden" : @(NO),
-                                                                @"warningLevel" : @(kMGSErrorAccess)
+                                                                @"warningLevel" : @(kMGSErrorCategoryAccess)
                                                                 }],
 
                           [SMLSyntaxError errorWithDictionary:@{
                                                                 @"description" : @"Sample error 2.",
                                                                 @"line" : @(4),
                                                                 @"hidden" : @(YES),
-                                                                @"warningLevel" : @(kMGSErrorPanic)
+                                                                @"warningLevel" : @(kMGSErrorCategoryPanic)
                                                                 }],
                           [SMLSyntaxError errorWithDictionary:@{
                                                                 @"description" : @"Sample error 3.",
                                                                 @"line" : @(37),
                                                                 @"hidden" : @(NO),
-                                                                @"warningLevel" : @(kMGSErrorDocument)
+                                                                @"warningLevel" : @(kMGSErrorCategoryDocument)
                                                                 }],
                           [SMLSyntaxError errorWithDictionary:@{
                                                                 @"description" : @"Sample error 4.",
                                                                 @"line" : @(37),
                                                                 @"hidden" : @(NO),
-                                                                @"warningLevel" : @(kMGSErrorDocument)
+                                                                @"warningLevel" : @(kMGSErrorCategoryDocument)
                                                                 }],
                           [NSString stringWithFormat:@"%@", @"I don't belong here."],
                           [SMLSyntaxError errorWithDictionary:@{
                                                                 @"description" : @"Sample error 5.",
                                                                 @"line" : @(189),
                                                                 @"hidden" : @(NO),
-                                                                @"warningLevel" : @(kMGSErrorError)
+                                                                @"warningLevel" : @(kMGSErrorCategoryError)
                                                                 }],
                           [SMLSyntaxError errorWithDictionary:@{
                                                                 @"description" : @"Sample error 6.",
                                                                 @"line" : @(212),
                                                                 @"hidden" : @(YES),
-                                                                @"warningLevel" : @(kMGSErrorPanic)
+                                                                @"warningLevel" : @(kMGSErrorCategoryPanic)
                                                                 }],
                           ];
 }
@@ -71,7 +71,7 @@
     [super tearDown];
 }
 
-- (void)testLinesWithErrorsInArray
+- (void)test_linesWithErrorsInArray
 {
     NSArray *result = [[MGSSyntaxErrorController linesWithErrorsInArray:self.syntaxErrors] sortedArrayUsingSelector:@selector(compare:)];
     NSArray *expects = @[@(4), @(37), @(189)];
@@ -81,7 +81,7 @@
 
 
 
-- (void)testErrorCountForLine
+- (void)test_errorCountForLine
 {
     NSInteger result4 = [MGSSyntaxErrorController errorCountForLine:4 inArray:self.syntaxErrors];
     NSInteger result37 = [MGSSyntaxErrorController errorCountForLine:37 inArray:self.syntaxErrors];
@@ -92,20 +92,20 @@
 }
 
 
-- (void)testErrorForLine
+- (void)test_errorForLine
 {
     // We should get kMGSErrorAccess, because the other error is hidden.
-    MGSErrorType result4 = [[MGSSyntaxErrorController errorForLine:4 inArray:self.syntaxErrors] warningLevel];
+    float result4 = [[MGSSyntaxErrorController errorForLine:4 inArray:self.syntaxErrors] warningLevel];
 
     // We should get @"Sample error 3." because error level is the same, and this is the first one.
     NSString *result37 = [[MGSSyntaxErrorController errorForLine:37 inArray:self.syntaxErrors] description];
 
-    XCTAssert(result4 == kMGSErrorAccess && [result37 isEqualToString:@"Sample error 3."]);
+    XCTAssert(result4 == kMGSErrorCategoryAccess && [result37 isEqualToString:@"Sample error 3."]);
 
 }
 
 
-- (void)testErrorsForLine
+- (void)test_errorsForLine
 {
     SMLSyntaxError *testContent = [[MGSSyntaxErrorController errorsForLine:4 inArray:self.syntaxErrors] objectAtIndex:0];
     NSInteger testQuantity = [[MGSSyntaxErrorController errorsForLine:37 inArray:self.syntaxErrors] count];
@@ -114,7 +114,7 @@
 }
 
 
-- (void)testNonHiddenErrorsInArray
+- (void)test_nonHiddenErrorsInArray
 {
     NSInteger testQuantity = [[MGSSyntaxErrorController nonHiddenErrorsInArray:self.syntaxErrors] count];
 
@@ -122,7 +122,7 @@
 }
 
 
-- (void)testSanitizedErrorsInArray
+- (void)test_sanitizedErrorsInArray
 {
     BOOL pass = YES;
     for (id object in [MGSSyntaxErrorController sanitizedErrorsInArray:self.syntaxErrors])
@@ -137,7 +137,7 @@
 }
 
 
-- (void)testErrorDecorationsInArray
+- (void)test_errorDecorationsInArray
 {
     NSDictionary *resultDict = [MGSSyntaxErrorController errorDecorationsInArray:self.syntaxErrors];
     NSImage *image = [resultDict objectForKey:@(189)];
@@ -150,7 +150,7 @@
 }
 
 
-- (void)testErrorDecorationsInArraySize
+- (void)test_errorDecorationsInArraySize
 {
     NSDictionary *resultDict = [MGSSyntaxErrorController errorDecorationsInArray:self.syntaxErrors size:NSMakeSize(123.0, 119.4)];
     NSImage *image = [resultDict objectForKey:@(4)];

--- a/MGSFragaria Tests/SMLSyntaxErrorTests.m
+++ b/MGSFragaria Tests/SMLSyntaxErrorTests.m
@@ -1,0 +1,78 @@
+//
+//  SMLSyntaxErrorTests.m
+//  Fragaria
+//
+//  Created by Jim Derry on 2/16/15.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+#import "SMLSyntaxError.h"
+#import <XCTest/XCTest.h>
+
+@interface SMLSyntaxErrorTests : XCTestCase
+
+@property (nonatomic,strong) NSArray *syntaxErrors;
+
+@end
+
+@implementation SMLSyntaxErrorTests
+
+- (void)setUp {
+    [super setUp];
+	self.syntaxErrors = @[
+						  [SMLSyntaxError errorWithDictionary:@{
+																@"description" : @"Sample error 1.",
+																@"line" : @(4),
+																@"hidden" : @(NO),
+																@"warningLevel" : @(kMGSErrorCategoryAccess)
+																}],
+						  
+						  [SMLSyntaxError errorWithDictionary:@{
+																@"description" : @"Sample error 2.",
+																@"line" : @(4),
+																@"hidden" : @(YES),
+																@"warningLevel" : @(601.223) // panic
+																}],
+						  [SMLSyntaxError errorWithDictionary:@{
+																@"description" : @"Sample error 3.",
+																@"line" : @(37),
+																@"hidden" : @(NO),
+																@"warningLevel" : @(kMGSErrorCategoryDocument)
+																}],
+						  [SMLSyntaxError errorWithDictionary:@{
+																@"description" : @"Sample error 4.",
+																@"line" : @(37),
+																@"hidden" : @(NO),
+																@"warningLevel" : @(kMGSErrorCategoryDocument)
+																}],
+						  [NSString stringWithFormat:@"%@", @"I don't belong here."],
+						  [SMLSyntaxError errorWithDictionary:@{
+																@"description" : @"Sample error 5.",
+																@"line" : @(189),
+																@"hidden" : @(NO),
+																@"warningLevel" : @(kMGSErrorCategoryError)
+																}],
+						  [SMLSyntaxError errorWithDictionary:@{
+																@"description" : @"Sample error 6.",
+																@"line" : @(212),
+																@"hidden" : @(YES),
+																}],
+						  ];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)test_defaultImageForWarningLevel
+{
+	SMLSyntaxError *test1 = self.syntaxErrors[1]; // sample error 2, panic.
+	NSString *result1 = [SMLSyntaxError defaultImageForWarningLevel:test1.warningLevel].name;
+	NSString *expect1 = @"messagesPanic";
+	
+	XCTAssert([result1 isEqualToString:expect1]);
+}
+
+
+@end

--- a/MGSFragaria Tests/SMLSyntaxErrorTests.m
+++ b/MGSFragaria Tests/SMLSyntaxErrorTests.m
@@ -46,12 +46,11 @@
 																@"hidden" : @(NO),
 																@"warningLevel" : @(kMGSErrorCategoryDocument)
 																}],
-						  [NSString stringWithFormat:@"%@", @"I don't belong here."],
 						  [SMLSyntaxError errorWithDictionary:@{
 																@"description" : @"Sample error 5.",
 																@"line" : @(189),
 																@"hidden" : @(NO),
-																@"warningLevel" : @(kMGSErrorCategoryError)
+																@"warningLevel" : @(522.2)
 																}],
 						  [SMLSyntaxError errorWithDictionary:@{
 																@"description" : @"Sample error 6.",
@@ -67,11 +66,33 @@
 
 - (void)test_defaultImageForWarningLevel
 {
-	SMLSyntaxError *test1 = self.syntaxErrors[1]; // sample error 2, panic.
-	NSString *result1 = [SMLSyntaxError defaultImageForWarningLevel:test1.warningLevel].name;
-	NSString *expect1 = @"messagesPanic";
+	SMLSyntaxError *test;
+	NSImage *result;
+	NSImage *expect;
 	
-	XCTAssert([result1 isEqualToString:expect1]);
+	// Tests values over 600
+	test = self.syntaxErrors[1];
+	result = [SMLSyntaxError defaultImageForWarningLevel:test.warningLevel];
+	expect = [[NSBundle bundleForClass:[SMLSyntaxError class]] imageForResource:@"messagesPanic"];
+	XCTAssert([[result TIFFRepresentation] isEqualToData:[expect TIFFRepresentation]]);
+
+	// Tests the default case where the value is 0.
+	test = self.syntaxErrors[5];
+	result = [SMLSyntaxError defaultImageForWarningLevel:test.warningLevel];
+	expect = [[NSBundle bundleForClass:[SMLSyntaxError class]] imageForResource:@"messagesWarning"];
+	XCTAssert([[result TIFFRepresentation] isEqualToData:[expect TIFFRepresentation]]);
+	
+	// Tests a standard case where the value is not exact.
+	test = self.syntaxErrors[4];
+	result = [SMLSyntaxError defaultImageForWarningLevel:test.warningLevel];
+	expect = [[NSBundle bundleForClass:[SMLSyntaxError class]] imageForResource:@"messagesError"];
+	XCTAssert([[result TIFFRepresentation] isEqualToData:[expect TIFFRepresentation]]);
+
+	// Tests the default case where the value is exact.
+	test = self.syntaxErrors[3];
+	result = [SMLSyntaxError defaultImageForWarningLevel:test.warningLevel];
+	expect = [[NSBundle bundleForClass:[SMLSyntaxError class]] imageForResource:@"messagesDocument"];
+	XCTAssert([[result TIFFRepresentation] isEqualToData:[expect TIFFRepresentation]]);
 }
 
 

--- a/MGSFragaria.m
+++ b/MGSFragaria.m
@@ -344,6 +344,7 @@ char kcLineWrapPrefChanged;
 
     MGSLineNumberView *lineNumberView;
     lineNumberView = [[MGSLineNumberView alloc] initWithScrollView:textScrollView];
+	lineNumberView.userData = self;
     [textScrollView setVerticalRulerView:lineNumberView];
     [textScrollView setHasVerticalRuler:YES];
     [textScrollView setHasHorizontalRuler:NO];

--- a/MGSLineNumberView.h
+++ b/MGSLineNumberView.h
@@ -59,6 +59,7 @@
 }
 
 @property (nonatomic) id <MGSBreakpointDelegate> breakpointDelegate;
+@property (nonatomic,assign) id userData;
 
 @property (nonatomic) NSFont *font;
 @property (nonatomic) NSColor *textColor;

--- a/MGSLineNumberView.m
+++ b/MGSLineNumberView.m
@@ -656,7 +656,7 @@
     [warningButton setTranslatesAutoresizingMaskIntoConstraints:NO];
 
     // There may be multiple errors for this line, so find the one with the highest warningStyle.
-    MGSErrorType style = [[[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hideWarning == %@)", line, @(NO)]] valueForKeyPath:@"@max.warningStyle"] integerValue];
+    float style = [[[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hideWarning == %@)", line, @(NO)]] valueForKeyPath:@"@max.warningStyle"] floatValue];
     [warningButton setImage:[SMLSyntaxError imageForWarningStyle:style]];
     [[warningButton image] setSize:NSMakeSize(16.0, 16.0)];
 

--- a/MGSLineNumberView.m
+++ b/MGSLineNumberView.m
@@ -470,7 +470,10 @@
     textAttributes = [self textAttributes];
     
     lines = [self lineIndices];
-    linesWithBreakpoints = [_breakpointDelegate breakpointsForFile:nil];
+	
+	if (_breakpointDelegate && [_breakpointDelegate respondsToSelector:@selector(breakpointsForFile:)]) {
+		linesWithBreakpoints = [_breakpointDelegate breakpointsForFile:nil];
+	}
 
     linesWithErrors = [[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"hideWarning == %@", @(NO)]] valueForKeyPath:@"@distinctUnionOfObjects.line"];
     startingLine = _startingLineNumber + 1;
@@ -681,17 +684,18 @@
 {
     NSPoint					location;
     NSUInteger				line;
+	
+	if (_breakpointDelegate && [_breakpointDelegate respondsToSelector:@selector(toggleBreakpointForFile:onLine:)]) {
 
-    if (!_breakpointDelegate) return;
-
-    location = [self convertPoint:[theEvent locationInWindow] fromView:nil];
-    line = [self lineNumberForLocation:location.y];
-    
-    if (line != NSNotFound)
-    {
-        [_breakpointDelegate toggleBreakpointForFile:nil onLine:(int)line+1];
-        [self setNeedsDisplay:YES];
-    }
+		location = [self convertPoint:[theEvent locationInWindow] fromView:nil];
+		line = [self lineNumberForLocation:location.y];
+		
+		if (line != NSNotFound)
+		{
+			[_breakpointDelegate toggleBreakpointForFile:nil onLine:(int)line+1];
+			[self setNeedsDisplay:YES];
+		}
+	}
 }
 
 

--- a/MGSSyntaxErrorController.m
+++ b/MGSSyntaxErrorController.m
@@ -29,7 +29,7 @@
 + (SMLSyntaxError *)errorForLine:(NSInteger)line inArray:(NSArray *)errorArray
 {
     errorArray = [[self class] sanitizedErrorsInArray:errorArray];
-    MGSErrorType highestErrorLevel = [[[[self class] errorsForLine:line inArray:errorArray] valueForKeyPath:@"@max.warningStyle"] integerValue];
+    float highestErrorLevel = [[[[self class] errorsForLine:line inArray:errorArray] valueForKeyPath:@"@max.warningStyle"] floatValue];
     NSArray* errors = [[self errorsForLine:line inArray:errorArray] filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"warningStyle = %@", @(highestErrorLevel)]];
 
     return errors.firstObject;

--- a/SMLSyntaxColouring.m
+++ b/SMLSyntaxColouring.m
@@ -1498,7 +1498,7 @@ NSString *SMLSyntaxGroupSecondStringPass2 = @"secondStringPass2";
                     // Note that's only highlighting this row once, so there's only one opportunity
                     // to set an error image. Let's choose the highest level of error if there are
                     // multiple errors for this line.
-                    MGSErrorType style = [[[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hideWarning == %@)", @(err.line), @(NO)]] valueForKeyPath:@"@max.warningStyle"] integerValue];
+                    float style = [[[self.syntaxErrors filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"(line == %@) AND (hideWarning == %@)", @(err.line), @(NO)]] valueForKeyPath:@"@max.warningStyle"] floatValue];
                     NSImage *warnImg = [SMLSyntaxError imageForWarningStyle:style];
                     [warnImg setSize:NSMakeSize(linePos.size.height,linePos.size.height)];
                     [warningButton setImage:warnImg];

--- a/SMLSyntaxError.h
+++ b/SMLSyntaxError.h
@@ -10,29 +10,31 @@
 #import <Foundation/Foundation.h>
 
 /**
- *  MGSErrorType describes the warning level for an error, ranging from least severe to most severe.
- *  This can be used to automatically provide an appropriate image for error displays.
+ *  MGSErrorType describes the warningLevel for an error, ranging from least severe to most severe.
+ *  This can be used to automatically provide an appropriate image for error displays. The constants
+ *  below can serve as as a convenience for setting warningLevel, and as long as the warningLevel is
+ *  within the ranges described below the default warningImage can be used. This allows you to implement
+ *  varying warningLevels within a "category."
+ *
+ **/
+
+extern float const kMGSErrorCategoryAccess;   ///< warningLevel > 0.0, <= 100.0
+extern float const kMGSErrorCategoryConfig;   ///< warningLevel > 100.0, <= 200.0
+extern float const kMGSErrorCategoryDocument; ///< warningLevel > 200.0, <= 300.0
+extern float const kMGSErrorCategoryInfo;     ///< warningLevel > 300.0, <= 400.0
+extern float const kMGSErrorCategoryWarning;  ///< warningLevel > 400.0, <= 500.0
+extern float const kMGSErrorCategoryError;    ///< warningLevel > 500.0, <= 600.0
+extern float const kMGSErrorCategoryPanic;    ///< warningLevel > 600.0
+extern float const kMGSErrorCategoryDefault;  ///< warningLevel = kMGSErrorCategoryWarning
+
+
+/**
+ *  SMLSyntaxError describes a class that stores syntaxErrors to be handled by Fragaria.
  *
  *  @discussion Components using this class are not currently KVO compliant and do not observe changes
  *  to instances of this class. They expect an NSArray of this class for which they will respond to
  *  changes. Do not modify instances of this class once assigned to your instance of Fragaria; instead
  *  assign a new copy of your syntaxErrors array.
- **/
-typedef NS_ENUM(NSInteger, MGSErrorType)
-{
-    kMGSErrorDefault  = 0,
-    kMGSErrorAccess   = 1,
-    kMGSErrorConfig   = 2,
-    kMGSErrorDocument = 3,
-    kMGSErrorInfo     = 4,
-    kMGSErrorWarning  = 5,
-    kMGSErrorError    = 6,
-    kMGSErrorPanic    = 7
-};
-
-
-/**
- *  SMLSyntaxError describes a class that stores syntaxErrors to be handled by Fragaria.
  **/
 
 @interface SMLSyntaxError : NSObject
@@ -43,9 +45,9 @@ typedef NS_ENUM(NSInteger, MGSErrorType)
 /**
  *  This class method will return an image that represents the property `warningLevel`.
  *  The default images are stored in and loaded from the framework bundle automatically.
- *  @param level indicates the level of this error.
+ *  @param level indicates the level (severity) of this error.
  **/
-+ (NSImage *)defaultImageForWarningLevel:(MGSErrorType)level;
++ (NSImage *)defaultImageForWarningLevel:(float)level;
 
 
 /**
@@ -71,7 +73,7 @@ typedef NS_ENUM(NSInteger, MGSErrorType)
  *  @deprecated Use defaultImageForWarningLevel: instead.
  *  @param style indicates the level of this error.
  **/
-+ (NSImage *)imageForWarningStyle:(MGSErrorType)style __deprecated_msg("Use defaultImageForWarningLevel: instead.");
++ (NSImage *)imageForWarningStyle:(float)style __deprecated_msg("Use defaultImageForWarningLevel: instead.");
 
 
 /// @name Properties
@@ -85,7 +87,7 @@ typedef NS_ENUM(NSInteger, MGSErrorType)
 @property (nonatomic,copy) NSColor *errorLineHighlightColor;       ///< The color to use to highlight lines that have syntax errors.
 @property (nonatomic,copy) NSColor *errorBackgroundHighlightColor; ///< The color to use to highlight the background of specific errors.
 @property (nonatomic,copy) NSColor *errorForegroundHilightColor;   ///< The color to use to highlight the foreground of specific errors.
-@property (nonatomic,assign) MGSErrorType warningLevel;            ///< The warning level or severity of this syntax error.
+@property (nonatomic,assign) float warningLevel;                   ///< The warning level or severity of this syntax error.
 
 /**
  *  Specifies an image that should be associated with this syntax error.
@@ -107,7 +109,7 @@ typedef NS_ENUM(NSInteger, MGSErrorType)
 @property (nonatomic,copy) NSString* code __deprecated_msg("This property is not used.");
 
 /// @deprecated Use the warningLevel property instead.
-@property (nonatomic,assign) MGSErrorType warningStyle __deprecated_msg("Use the warningLevel property instead.");
+@property (nonatomic,assign) float warningStyle __deprecated_msg("Use the warningLevel property instead.");
 
 /// @deprecated Use the hidden property instead.
 @property (nonatomic,assign) BOOL hideWarning __deprecated_msg("Use the hidden property instead.");

--- a/SMLSyntaxError.m
+++ b/SMLSyntaxError.m
@@ -8,6 +8,17 @@
 
 #import "SMLSyntaxError.h"
 
+
+float const kMGSErrorCategoryAccess = 100;
+float const kMGSErrorCategoryConfig = 200;
+float const kMGSErrorCategoryDocument = 300;
+float const kMGSErrorCategoryInfo = 400;
+float const kMGSErrorCategoryWarning = 500;
+float const kMGSErrorCategoryError = 600;
+float const kMGSErrorCategoryPanic = FLT_MAX;
+float const kMGSErrorCategoryDefault = 500;
+
+
 @implementation SMLSyntaxError
 
 // automatic
@@ -24,11 +35,38 @@
 
 #pragma mark - Class Methods
 
-+ (NSImage *)defaultImageForWarningLevel:(MGSErrorType)level
++ (NSImage *)defaultImageForWarningLevel:(float)level
 {
-    // Note these are in order by MGSErrorType. @todo: Bounds checking.
-    NSArray *imageNames = @[@"messagesWarning", @"messagesAccess", @"messagesConfig", @"messagesDocument", @"messagesInfo", @"messagesWarning",@"messagesError", @"messagesPanic"];
-    NSImage *warningImage = [[NSBundle bundleForClass:[self class]] imageForResource:imageNames[level]];
+	NSString *imageName;
+	int result = (int)ceil(level/100.0);
+	NSLog(@"%f, %d", level, result);
+	switch ((int)ceil(level/100.0))
+	{
+		case 1:
+			imageName  = @"messagesAccess";
+			break;
+		case 2:
+			imageName  = @"messagesConfig";
+			break;
+		case 3:
+			imageName  = @"messagesDocument";
+			break;
+		case 4:
+			imageName  = @"messagesInfo";
+			break;
+		case 0:
+		case 5:
+			imageName  = @"messagesWarning";
+			break;
+		case 6:
+			imageName  = @"messagesError";
+			break;
+		default:
+			imageName  = @"messagesPanic";
+			break;
+	}
+
+    NSImage *warningImage = [[NSBundle bundleForClass:[self class]] imageForResource:imageName];
     return warningImage;
 }
 
@@ -53,7 +91,7 @@
 #pragma mark - Deprecated Class Methods
 
 
-+ (NSImage *)imageForWarningStyle:(MGSErrorType)style
++ (NSImage *)imageForWarningStyle:(float)style
 {
     return [[self class] defaultImageForWarningLevel:style];
 }
@@ -128,12 +166,12 @@
 #pragma mark - Deprecated Properties
 
 
-- (void)setWarningStyle:(MGSErrorType)style
+- (void)setWarningStyle:(float)style
 {
     self.warningLevel = style;
 }
 
-- (MGSErrorType)warningStyle
+- (float)warningStyle
 {
     return self.warningLevel;
 }

--- a/SMLSyntaxError.m
+++ b/SMLSyntaxError.m
@@ -67,7 +67,6 @@ float const kMGSErrorCategoryDefault = 500;
 	}
 
     NSImage *warningImage = [[NSBundle bundleForClass:[self class]] imageForResource:imageName];
-	[warningImage setName:imageName]; // better for unit testing, name is otherwise nil.
     return warningImage;
 }
 

--- a/SMLSyntaxError.m
+++ b/SMLSyntaxError.m
@@ -67,6 +67,7 @@ float const kMGSErrorCategoryDefault = 500;
 	}
 
     NSImage *warningImage = [[NSBundle bundleForClass:[self class]] imageForResource:imageName];
+	[warningImage setName:imageName]; // better for unit testing, name is otherwise nil.
     return warningImage;
 }
 


### PR DESCRIPTION
I reworked the breakpoint delegate a little bit to prepare for re-working the errors in the gutter.
- delegate methods made optional, as app might not use breakpoints.
- deprecated the current delegates with the useless ForFile: syntax.
- new methods have a sender. Unfortunately it meant assigning a weak reference to the gutter view so that delegates would know the sender. If an application manages multiple Fragaria instances, then previous implementation provides no means for the delegate to know which instance sent the message. This was done as a generic id called userData.
- the demo application allows setting and clearing breakpoints in the gutter simply by clicking.

This was done in preparation for changing the NSButtons to NSImages, as now detection of the click in each line will have to discriminate between the breakpoint marker and the error image.

I hate the generic id userData. It's innocuous, but it bugs me somewhat. Any suggestions on that point?
