### PR TITLE
Docspec must die (part 2)

### DIFF
--- a/MGSFragaria.h
+++ b/MGSFragaria.h
@@ -42,7 +42,6 @@ extern NSString * const MGSFODelegate;
 extern NSString * const MGSFOBreakpointDelegate;
 extern NSString * const MGSFOSyntaxColouringDelegate;
 extern NSString * const ro_MGSFOLineNumbers; // readonly
-extern NSString * const ro_MGSFOSyntaxColouring; // readonly
 
 
 @class MGSTextMenuController;               // @todo: (jsd) can be removed when the textMenuController deprecation is removed.

--- a/MGSFragariaPrivate.h
+++ b/MGSFragariaPrivate.h
@@ -29,12 +29,18 @@
 @property (nonatomic, strong, readwrite) MGSSyntaxErrorController *syntaxErrorController;
 
 
+/**
+ * Instances of this class will perform syntax highlighting in text views.
+ */
+@property (nonatomic, strong, readwrite) SMLSyntaxColouring *syntaxColouring;
+
+
 #pragma mark - Internal Properties
 
 /**
  *  The internal autoCompleteDelegate
  **/
-@property (nonatomic, strong) id<SMLAutoCompleteDelegate> internalAutoCompleteDelegate; // @todo: make assign. See accessor notes.
+@property (nonatomic, assign, readonly) id<SMLAutoCompleteDelegate> internalAutoCompleteDelegate;
 
 
 @end

--- a/MGSTextMenuController.m
+++ b/MGSTextMenuController.m
@@ -129,7 +129,7 @@ static id sharedInstance = nil;
 	}
     // Comment Or Uncomment
     else if (action == @selector(commentOrUncommentAction:) ) {
-		if ([[[[[responder fragaria] objectForKey:ro_MGSFOSyntaxColouring] syntaxDefinition] firstSingleLineComment] isEqualToString:@""]) {
+		if ([[[[[responder fragaria] valueForKey:@"syntaxColouring"] syntaxDefinition] firstSingleLineComment] isEqualToString:@""]) {
 			enableMenuItem = NO;
 		}
 	} 

--- a/SMLSyntaxColouringDelegate.h
+++ b/SMLSyntaxColouringDelegate.h
@@ -48,7 +48,7 @@ enum {
 typedef NSInteger SMLSyntaxGroupInteger;
 
 /**
- *  A class implementing the SMLSyntaxColoringDelegate protocol can customize or
+ *  A class implementing the SMLSyntaxColouringDelegate protocol can customize or
  *  override the default syntax coloring.
  *
  *  Arguments used in the delegate methods

--- a/SMLTextView+MGSTextActions.m
+++ b/SMLTextView+MGSTextActions.m
@@ -38,7 +38,7 @@
         }
     } else if (action == @selector(commentOrUncomment:) ) {
         // Comment Or Uncomment
-        if ([[[[self.fragaria objectForKey:ro_MGSFOSyntaxColouring] syntaxDefinition] firstSingleLineComment] isEqualToString:@""]) {
+        if ([[[self.fragaria.syntaxColouring syntaxDefinition] firstSingleLineComment] isEqualToString:@""]) {
             enableItem = NO;
         }
     } else {
@@ -743,7 +743,7 @@
 - (IBAction)commentOrUncomment:(id)sender
 {
     NSString *completeString = [self string];
-    NSString *commentString = [[[self.fragaria objectForKey:ro_MGSFOSyntaxColouring] syntaxDefinition] firstSingleLineComment];
+    NSString *commentString = [[self.fragaria.syntaxColouring syntaxDefinition] firstSingleLineComment];
     NSUInteger commentStringLength = [commentString length];
     if ([commentString isEqualToString:@""] || [completeString length] < commentStringLength) {
         NSBeep();


### PR DESCRIPTION
Last one for me tonight; I'll wait and see what else you add in the morning.

This simply adds syntaxColouring as a Fragaria component property and pulls it out of the docSpec.
