### PR TITLE
MGSFragariaView improvements

### DIFF
--- a/Applications/MGSFragariaView/Features.xib
+++ b/Applications/MGSFragariaView/Features.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
     </dependencies>
     <objects>
@@ -33,7 +34,7 @@
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
                                     <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.isSyntaxColoured" id="OKd-Bs-Jjw">
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.syntaxColoured" id="sd1-5m-Oey">
                                             <dictionary key="options">
                                                 <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
                                                 <bool key="NSConditionallySetsEnabled" value="NO"/>
@@ -81,7 +82,7 @@
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
                                     <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsWarningsInGutter" id="nlo-Mo-T1h">
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsSyntaxErrors" id="SqS-Gd-u55">
                                             <dictionary key="options">
                                                 <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
                                                 <bool key="NSConditionallySetsEnabled" value="NO"/>
@@ -125,7 +126,7 @@
                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                     <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.gutterMinimumWidth" id="gRU-Qs-wS2">
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.minimumGutterWidth" id="xVR-aM-C4m">
                                             <dictionary key="options">
                                                 <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
                                                 <bool key="NSConditionallySetsEditable" value="NO"/>
@@ -190,22 +191,6 @@
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Txw-Ti-hMm">
-                                    <rect key="frame" x="16" y="21" width="129" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Auto Spell Check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="We2-2u-6sN">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.autoSpellCheck" id="oUJ-qd-KaL">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
                             </subviews>
                         </view>
                         <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
@@ -256,7 +241,7 @@
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
                                     <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewBottom.showsWarningsInGutter" id="s5o-KJ-pLP">
+                                        <binding destination="-2" name="value" keyPath="self.viewBottom.showsSyntaxErrors" id="b07-XA-94C">
                                             <dictionary key="options">
                                                 <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
                                                 <bool key="NSConditionallySetsEnabled" value="NO"/>
@@ -272,7 +257,7 @@
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
                                     <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewBottom.isSyntaxColoured" id="Okn-Dw-r2G">
+                                        <binding destination="-2" name="value" keyPath="self.viewBottom.syntaxColoured" id="rJ4-4b-Dol">
                                             <dictionary key="options">
                                                 <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
                                                 <bool key="NSConditionallySetsEnabled" value="NO"/>
@@ -364,7 +349,7 @@
                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                     <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewBottom.gutterMinimumWidth" id="gk1-fb-LiG">
+                                        <binding destination="-2" name="value" keyPath="self.viewBottom.minimumGutterWidth" id="5wd-NZ-EZG">
                                             <dictionary key="options">
                                                 <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
                                                 <bool key="NSConditionallySetsEditable" value="NO"/>
@@ -381,22 +366,6 @@
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QRi-tU-qs1">
-                                    <rect key="frame" x="16" y="20" width="129" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Auto Spell Check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="GV8-BF-ZQj">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewBottom.autoSpellCheck" id="td4-kB-eEP">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
                             </subviews>
                         </view>
                         <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>

--- a/Applications/MGSFragariaView/MainMenu.xib
+++ b/Applications/MGSFragariaView/MainMenu.xib
@@ -752,7 +752,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -763,8 +763,8 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="self.syntaxDefinitionName" value="html"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
-                            <outlet property="breakPointDelegate" destination="Voe-Tx-rLC" id="aeY-qe-8QV"/>
-                            <outlet property="delegate" destination="Voe-Tx-rLC" id="O5d-GF-XaD"/>
+                            <outlet property="breakpointDelegate" destination="Voe-Tx-rLC" id="JO2-VS-Gb0"/>
+                            <outlet property="textViewDelegate" destination="Voe-Tx-rLC" id="PK0-P8-GZJ"/>
                         </connections>
                     </customView>
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="5Ef-Wd-Tpu" userLabel="Bottom View" customClass="MGSFragariaView">
@@ -773,7 +773,7 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="self.syntaxDefinitionName" value="html"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
-                            <outlet property="delegate" destination="Voe-Tx-rLC" id="Gcz-EN-niR"/>
+                            <outlet property="textViewDelegate" destination="Voe-Tx-rLC" id="KeG-m4-eKs"/>
                         </connections>
                     </customView>
                 </subviews>

--- a/Fragaria.xcodeproj/project.pbxproj
+++ b/Fragaria.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		D034C8161A998324003D3A41 /* MASPreferencesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = D034C8121A998324003D3A41 /* MASPreferencesWindowController.m */; };
 		D034C81C1A9984A1003D3A41 /* PrefsFontsAndColorsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D034C8191A9984A1003D3A41 /* PrefsFontsAndColorsViewController.m */; };
 		D034C81D1A9984A1003D3A41 /* PrefsTextEditingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D034C81B1A9984A1003D3A41 /* PrefsTextEditingViewController.m */; };
+		D04A0DF81AAEAD7C00667E4D /* MGSFragariaAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = D04A0DF71AAEAD7C00667E4D /* MGSFragariaAPI.h */; };
 		D08359DB1A9F0446001B7B50 /* FeaturesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = D08359D91A9F0446001B7B50 /* FeaturesWindowController.m */; };
 		D08359E11AA0875E001B7B50 /* MGSPreferencesObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = D08359DE1AA0875E001B7B50 /* MGSPreferencesObserver.m */; };
 		D0AB50F01A91CDC200A6DF58 /* SMLSyntaxErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AB50EF1A91CDC200A6DF58 /* SMLSyntaxErrorTests.m */; };
@@ -256,6 +257,7 @@
 		D034C8191A9984A1003D3A41 /* PrefsFontsAndColorsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PrefsFontsAndColorsViewController.m; path = Applications/MGSFragariaView/PrefsFontsAndColorsViewController.m; sourceTree = "<group>"; };
 		D034C81A1A9984A1003D3A41 /* PrefsTextEditingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrefsTextEditingViewController.h; path = Applications/MGSFragariaView/PrefsTextEditingViewController.h; sourceTree = "<group>"; };
 		D034C81B1A9984A1003D3A41 /* PrefsTextEditingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PrefsTextEditingViewController.m; path = Applications/MGSFragariaView/PrefsTextEditingViewController.m; sourceTree = "<group>"; };
+		D04A0DF71AAEAD7C00667E4D /* MGSFragariaAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSFragariaAPI.h; sourceTree = "<group>"; };
 		D08359D81A9F0446001B7B50 /* FeaturesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FeaturesWindowController.h; path = Applications/MGSFragariaView/FeaturesWindowController.h; sourceTree = "<group>"; };
 		D08359D91A9F0446001B7B50 /* FeaturesWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FeaturesWindowController.m; path = Applications/MGSFragariaView/FeaturesWindowController.m; sourceTree = "<group>"; };
 		D08359DD1AA0875E001B7B50 /* MGSPreferencesObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSPreferencesObserver.h; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 				E373BF121718A64700D71602 /* SMLAutoCompleteDelegate.h */,
 				0191FA7C1A881F280099B50D /* MGSDragOperationDelegate.h */,
 				019B80181A9E77330007D234 /* MGSFragariaTextViewDelegate.h */,
+				D04A0DF71AAEAD7C00667E4D /* MGSFragariaAPI.h */,
 				D0C146731A871A0B00DDE90A /* MGSFragariaView.h */,
 				D0C146741A871A0B00DDE90A /* MGSFragariaView.m */,
 				AB69B753118B830700903D1D /* MGSFragaria.h */,
@@ -687,6 +690,7 @@
 				D0C146751A871A0B00DDE90A /* MGSFragariaView.h in Headers */,
 				017FD58A1A7A992700B305FB /* MGSLineNumberView.h in Headers */,
 				E373BF131718A64700D71602 /* SMLAutoCompleteDelegate.h in Headers */,
+				D04A0DF81AAEAD7C00667E4D /* MGSFragariaAPI.h in Headers */,
 				AB8387AA171B4505004408F4 /* SMLSyntaxColouringDelegate.h in Headers */,
 				AB8387C5171D6115004408F4 /* SMLSyntaxDefinition.h in Headers */,
 				0191FA811A8829930099B50D /* SMLTextView+MGSTextActions.h in Headers */,

--- a/MGSFragaria.h
+++ b/MGSFragaria.h
@@ -301,7 +301,7 @@ extern NSString * const MGSFOAutoCompleteDelegate DEPRECATED_ATTRIBUTE;
 
 /** The text view delegate of this instance of Fragaria. This is an utility
  * accessor and setter for textView.delegate. */
-@property (nonatomic, weak) id<MGSFragariaTextViewDelegate> textViewDelegate;
+@property (nonatomic, weak) id<MGSFragariaTextViewDelegate, MGSDragOperationDelegate> textViewDelegate;
 
 /** Indicates whether or not the vertical scroller should be displayed.*/
 @property (nonatomic, assign) BOOL hasVerticalScroller;

--- a/MGSFragariaAPI.h
+++ b/MGSFragariaAPI.h
@@ -235,7 +235,7 @@
 
 /** The text view delegate of this instance of Fragaria. This is an utility
  * accessor and setter for textView.delegate. */
-@property (nonatomic, weak) id<MGSFragariaTextViewDelegate> textViewDelegate;
+@property (nonatomic, weak) id<MGSFragariaTextViewDelegate, MGSDragOperationDelegate> textViewDelegate;
 
 /** Indicates whether or not the vertical scroller should be displayed.*/
 @property (nonatomic, assign) BOOL hasVerticalScroller;

--- a/MGSFragariaAPI.h
+++ b/MGSFragariaAPI.h
@@ -1,0 +1,323 @@
+//
+//  MGSFragariaAPI.h
+//  Fragaria
+//
+//  Created by Jim Derry on 3/10/15.
+//
+//
+
+
+#import <Foundation/Foundation.h>
+#import "MGSFragaria.h"
+
+
+@class SMLTextView;
+@class MGSLineNumberView;
+@class SMLSyntaxColouring;
+
+/**
+ *  The MGSFragariaAPI protocol defines the properties and methods that are
+ *  used to control and configure an instance of MGSFragaria. It is adopted
+ *  by MGSFragariaView so that the API's are identical.
+ **/
+
+@protocol MGSFragariaAPI <NSObject>
+
+#pragma mark - Required Properties and Methods
+/// @name Required Properties and Methods
+@required
+
+
+#pragma mark - Accessing Fragaria's Views
+/// @name Accessing Fragaria's Views
+
+
+/** Fragaria's text view. */
+@property (nonatomic, strong, readonly) SMLTextView *textView;
+/** Fragaria's scroll view. */
+@property (nonatomic, strong, readonly) NSScrollView *scrollView;
+/** Fragaria's gutter view. */
+@property (nonatomic, strong, readonly) MGSLineNumberView *gutterView;
+/** Fragaria's syntax colouring object. */
+@property  (nonatomic, assign, readonly) SMLSyntaxColouring *syntaxColouring;
+
+
+#pragma mark - Accessing Text Content
+/// @name Accessing Text Content
+
+
+/** The plain text string of the text editor.*/
+@property (nonatomic, assign) NSString *string;
+
+/** The text editor string, including temporary attributes which
+ *  have been applied by the syntax highlighter. */
+@property (nonatomic, readonly) NSAttributedString *attributedStringWithTemporaryAttributesApplied;
+
+
+#pragma mark - Creating Split Panels
+/// @name Creating Split Panels
+
+
+/** Replaces the text storage object of this Fragaria instance's text view to
+ *  the specified text storage.
+ *
+ *  @discussion This allows two Fragaria instances to show the same text in a
+ *              split view, for example. Replacing the text storage directly
+ *              on the text view's layout manager is not supported, and will
+ *              not work properly. The two Fragaria instances will not share
+ *              their syntax definition or syntax errors.
+ *  @param textStorage The new text storage for this instance of Fragaria. */
+- (void)replaceTextStorage:(NSTextStorage*)textStorage;
+
+
+#pragma mark - Configuring Syntax Highlighting
+/// @name Configuring Syntax Highlighting
+
+
+/** Specifies whether the document shall be syntax highlighted.*/
+@property (nonatomic, getter=isSyntaxColoured) BOOL syntaxColoured;
+
+/** Specifies the current syntax definition name.*/
+@property (nonatomic, assign) NSString *syntaxDefinitionName;
+/** The syntax colouring delegate for this instance of Fragaria. The syntax
+ * colouring delegate gets notified of the start and end of each colouring pass
+ * so that it can modify the default syntax colouring provided by Fragaria. */
+@property (nonatomic, weak) id<SMLSyntaxColouringDelegate> syntaxColouringDelegate;
+
+/** Indicates if multiline strings should be coloured.*/
+@property BOOL coloursMultiLineStrings;
+/** Indicates if coloring should end at end of line.*/
+@property BOOL coloursOnlyUntilEndOfLine;
+
+
+#pragma mark - Configuring Autocompletion
+/// @name Configuring Autocompletion
+
+
+/** The autocomplete delegate for this instance of Fragaria. The autocomplete
+ * delegate provides a list of words that can be used by the autocomplete
+ * feature. If this property is nil, then the list of autocomplete words will
+ * be read from the current syntax highlighting dictionary. */
+@property (nonatomic, weak) id<SMLAutoCompleteDelegate> autoCompleteDelegate;
+
+/** Specifies the delay time for autocomplete, in seconds.*/
+@property double autoCompleteDelay;
+/** Specifies whether or not auto complete is enabled.*/
+@property BOOL autoCompleteEnabled;
+/** Specifies if autocompletion should include keywords.*/
+@property BOOL autoCompleteWithKeywords;
+
+
+#pragma mark - Highlighting the current line
+/// @name Highlighting the Current Line
+
+
+/** Specifies the color to use when highlighting the current line.*/
+@property (nonatomic, assign) NSColor *currentLineHighlightColour;
+/** Specifies whether or not the line with the cursor should be highlighted.*/
+@property (nonatomic, assign) BOOL highlightsCurrentLine;
+
+
+#pragma mark - Configuring the Gutter
+/// @name Configuring the Gutter
+
+
+/** Indicates whether or not the gutter is visible.*/
+@property (nonatomic, assign) BOOL showsGutter;
+/** Specifies the minimum width of the line number gutter.*/
+@property (nonatomic, assign) CGFloat minimumGutterWidth;
+
+/** Indicates whether or not line numbers are displayed when the gutter is visible.*/
+@property (nonatomic, assign) BOOL showsLineNumbers;
+/** Specifies the starting line number in the text view.*/
+@property (nonatomic, assign) NSUInteger startingLineNumber;
+
+/** Specifies the standard font for the line numbers in the gutter.*/
+@property (nonatomic, assign) NSFont *gutterFont;
+/** Specifies the standard color of the line numbers in the gutter.*/
+@property (nonatomic, assign) NSColor *gutterTextColour;
+
+
+#pragma mark - Showing Syntax Errors
+/// @name Showing Syntax Errors
+
+
+/** When set to an array containing SMLSyntaxError instances, Fragaria
+ *  use these instances to provide feedback to the user in the form of:
+ *   - highlighting lines and syntax errors in the text view.
+ *   - displaying warning icons in the gutter.
+ *   - providing a description of the syntax errors in popovers. */
+@property (nonatomic, assign) NSArray *syntaxErrors;
+
+/** Indicates whether or not error warnings are displayed.*/
+@property (nonatomic, assign) BOOL showsSyntaxErrors;
+
+
+#pragma mark - Showing Breakpoints
+/// @name Showing Breakpoints
+
+
+/** The breakpoint delegate for this instance of Fragaria. The breakpoint
+ * delegate is responsible of managing a list of lines where a breakpoint
+ * marker is present. */
+@property (nonatomic, weak) id<MGSBreakpointDelegate> breakpointDelegate;
+
+
+#pragma mark - Tabulation and Indentation
+/// @name Tabulation and Indentation
+
+
+/** Specifies the number of spaces per tab.*/
+@property (nonatomic, assign) NSInteger tabWidth;
+/** Specifies the automatic indentation width.*/
+@property (nonatomic, assign) NSUInteger indentWidth;
+/** Specifies whether spaces should be inserted instead of tab characters when indenting.*/
+@property (nonatomic, assign) BOOL indentWithSpaces;
+/** Specifies whether or not tab stops should be used when indenting.*/
+@property (nonatomic, assign) BOOL useTabStops;
+/** Indicates whether or not braces should be indented automatically.*/
+@property (nonatomic, assign) BOOL indentBracesAutomatically;
+/** Indicates whether or not new lines should be indented automatically.*/
+@property (nonatomic, assign) BOOL indentNewLinesAutomatically;
+
+
+#pragma mark - Automatic Bracing
+/// @name Automatic Bracing
+
+
+/** Specifies whether or not closing paretheses are inserted automatically.*/
+@property (nonatomic, assign) BOOL insertClosingParenthesisAutomatically;
+/** Specifies whether or not closing braces are inserted automatically.*/
+@property (nonatomic, assign) BOOL insertClosingBraceAutomatically;
+
+/** Specifies whether or not matching braces are shown in the editor.*/
+@property (nonatomic, assign) BOOL showsMatchingBraces;
+
+
+#pragma mark - Page Guide and Line Wrap
+/// @name Showing the Page Guide
+
+
+/** Indicates the column number at which the page guide appears.*/
+@property (nonatomic, assign) NSInteger pageGuideColumn;
+/** Specifies whether or not to show the page guide.*/
+@property (nonatomic, assign) BOOL showsPageGuide;
+
+/** Indicates whether or not line wrap is enabled.*/
+@property (nonatomic, assign) BOOL lineWrap;
+
+
+#pragma mark - Showing Invisible Characters
+/// @name Showing Invisible Characters
+
+
+/** Indicates whether or not invisible characters in the editor are revealed.*/
+@property (nonatomic, assign) BOOL showsInvisibleCharacters;
+/** Specifies the colour to render invisible characters in the text view.*/
+@property (nonatomic, assign) NSColor *textInvisibleCharactersColour;
+
+
+#pragma mark - Configuring Text Appearance
+/// @name Configuring Text Appearance
+
+
+/** Indicates the base (non-highlighted) text color.*/
+@property (nonatomic, assign) NSColor *textColor;
+/** Indicates the text view background color.*/
+@property NSColor *backgroundColor;
+/** Specifies the text editor font.*/
+@property (nonatomic, assign) NSFont *textFont;
+
+
+#pragma mark - Configuring Additional Text View Behavior
+/// @name Configuring Additional Text View Behavior
+
+
+/** The text view delegate of this instance of Fragaria. This is an utility
+ * accessor and setter for textView.delegate. */
+@property (nonatomic, weak) id<MGSFragariaTextViewDelegate> textViewDelegate;
+
+/** Indicates whether or not the vertical scroller should be displayed.*/
+@property (nonatomic, assign) BOOL hasVerticalScroller;
+/** Indicates the color of the insertion point.*/
+@property (nonatomic, assign) NSColor *insertionPointColor;
+/** Indicates whether or not the "rubber band" effect is disabled.*/
+@property (nonatomic, assign) BOOL scrollElasticityDisabled;
+
+/** Scrolls the text view to a specific line, selecting it if specified.
+ *  @param lineToGoTo Indicates the line the view should attempt to move to.
+ *  @param centered   Deprecated parameter.
+ *  @param highlight  Indicates whether or not the line should be selected. */
+- (void)goToLine:(NSInteger)lineToGoTo centered:(BOOL)centered highlight:(BOOL)highlight;
+
+
+#pragma mark - Optional Properties and Methods
+/// @name Optional Properties and Methods
+@optional
+
+
+#pragma mark - Syntax Highlighting Colours
+/// @name Syntax Highlighting Colours
+
+
+/** Specifies the autocomplete color **/
+@property (nonatomic, assign) NSColor *colourForAutocomplete;
+
+/** Specifies the attributes color **/
+@property (nonatomic, assign) NSColor *colourForAttributes;
+
+/** Specifies the commands color **/
+@property (nonatomic, assign) NSColor *colourForCommands;
+
+/** Specifies the comments color **/
+@property (nonatomic, assign) NSColor *colourForComments;
+
+/** Specifies the instructions color **/
+@property (nonatomic, assign) NSColor *colourForInstructions;
+
+/** Specifies the keywords color **/
+@property (nonatomic, assign) NSColor *colourForKeywords;
+
+/** Specifies the numbers color **/
+@property (nonatomic, assign) NSColor *colourForNumbers;
+
+/** Specifies the strings color **/
+@property (nonatomic, assign) NSColor *colourForStrings;
+
+/** Specifies the variables color **/
+@property (nonatomic, assign) NSColor *colourForVariables;
+
+
+#pragma mark - Syntax Highlighter Colouring Options
+/// @name Syntax Highlighter Colouring Options
+
+
+/** Specifies whether or not attributes should be syntax coloured. */
+@property (nonatomic, assign) BOOL coloursAttributes;
+
+/** Specifies whether or not attributes should be syntax coloured. */
+@property (nonatomic, assign) BOOL coloursAutocomplete;
+
+/** Specifies whether or not attributes should be syntax coloured. */
+@property (nonatomic, assign) BOOL coloursCommands;
+
+/** Specifies whether or not attributes should be syntax coloured. */
+@property (nonatomic, assign) BOOL coloursComments;
+
+/** Specifies whether or not attributes should be syntax coloured. */
+@property (nonatomic, assign) BOOL coloursInstructions;
+
+/** Specifies whether or not attributes should be syntax coloured. */
+@property (nonatomic, assign) BOOL coloursKeywords;
+
+/** Specifies whether or not attributes should be syntax coloured. */
+@property (nonatomic, assign) BOOL coloursNumbers;
+
+/** Specifies whether or not attributes should be syntax coloured. */
+@property (nonatomic, assign) BOOL coloursStrings;
+
+/** Specifies whether or not attributes should be syntax coloured. */
+@property (nonatomic, assign) BOOL coloursVariables;
+
+
+@end

--- a/MGSFragariaView.h
+++ b/MGSFragariaView.h
@@ -4,91 +4,26 @@
 //
 //  File created by Jim Derry on 2015/02/07.
 //
-//  Implements an NSView subclass that abstracts several characteristics of Fragaria,
-//  such as the use of Interface Builder to set delegates and assign key-value pairs.
-//  Also provides property abstractions for Fragaria's settings and methods.
 //
 
-#import <Cocoa/Cocoa.h>
-#import "MGSFragaria.h"
-#import "SMLTextView.h"
+#import <Foundation/Foundation.h>
+#import "MGSFragariaAPI.h"
 
+@class MGSFragaria;
 
 /**
  *  MGSFragariaView abstracts much of Fragaria's overhead into an IB-compatible view.
+ *  Implements an NSView subclass that abstracts several characteristics of Fragaria,
+ *  such as the use of Interface Builder to set delegates and assign key-value pairs.
+ *  Also provides two-way bindable property abstractions for Fragaria's settings
+ *  and methods.
+ *
+ *  Consult MGSFragariaAPI.h for properties and methods this class implements.
  **/
-@interface MGSFragariaView : NSView
+@interface MGSFragariaView : NSView <MGSFragariaAPI>
 
-
-#pragma mark - Properties - Delegates
-
-/** The delegate providing MGSFragariaTextViewDelegate methods. */
-@property (weak) IBOutlet id <MGSFragariaTextViewDelegate, MGSDragOperationDelegate> delegate;
-
-/** The delegate providing MGSBreakpointDelegate methods. */
-@property (weak) IBOutlet id <MGSBreakpointDelegate> breakPointDelegate;
-
-/** The delegate for providing SMLSyntaxColouringDelegate methods. */
-@property (weak) IBOutlet id <SMLSyntaxColouringDelegate> syntaxColoringDelegate;
-
-
-/*** @todo: (jsd) Probably fair to say we don't need these any more, or at least most of them. With Fragaria
-            moving to properties, it's no big deal for users to use myView.Fragaria instead of duplicating
-            every single property in this file.
- ***/
-
-#pragma mark - Properties - Document Support
-
-@property (assign) NSString *string;                     ///< The content of the text editor as a plain string.
-
-@property (assign) NSString *syntaxDefinitionName;       ///< Indicates the syntax definition name, which indicates how to highlight the text.
-
-@property (assign) NSArray *syntaxErrors;                ///< Contains an array of MGSSyntaxError objects, which can be displayed in the editor.
-
-
-#pragma mark - Properties - Overall Appearance and Display
-
-@property (assign) BOOL hasVerticalScroller;                           ///< Indicates whether or not the vertical scroller is always present.
-
-@property (assign) NSUInteger gutterMinimumWidth;                      ///< Specifies the minimum width of the line number gutter.
-
-@property (assign) BOOL isSyntaxColoured;                              ///< Indicates whether or not the text editor is using syntax highlighting.
-
-@property (assign) BOOL lineWrap;                                      ///< Indicates whether or not line wrap (word wrap) is on or off.
-
-@property (assign) BOOL scrollElasticityDisabled;                      ///< Indicates whether text text view's "rubber band" effect is disabled.
-
-@property (assign) BOOL showsLineNumbers;                              ///< Indicates whether or not the text editor is displaying line numbers when the gutter is visible.
-
-@property (assign) BOOL showsGutter;                                   ///< Indicates whether or not the text editor gutter is visible.
-
-@property (assign) BOOL showsWarningsInGutter;                         ///< Indicates whether or not error warnings are displayed in the gutter.
-
-@property (assign) NSUInteger startingLineNumber;                      ///< Indicates the starting line number of the text view.
-
-@property (assign) NSFont *textFont;                                   ///< Specifies the text editor font.
-
-@property (assign) NSColor *textInvisibleCharactersColour;             ///< Specifies the colour to render invisible characters in the text view.
-
-
-
-
-#pragma mark - KEY FRAGARIA METHOD PROMOTIONS
-
-/**
- *  If possible, moves the text editor view to the given line.
- *  @param lineToGoTo The line to go to.
- *  @param centered If yes, tries to center the line in the view.
- *  @param highlight If yes, highlights line temporarily.
- */
-- (void)goToLine:(NSInteger)lineToGoTo centered:(BOOL)centered highlight:(BOOL)highlight;
-
-
-#pragma mark - DIRECT ACCESS
-
-@property (strong, readonly) MGSFragaria *fragaria;   ///< A reference to the Fragaria instance owned by this view.
-
-@property (assign) SMLTextView *textView;              ///< Provides direct access to Fragaria's text view instance.
+/** Provides direct access to the view's instance of MGSFragaria. */
+@property (nonatomic, strong, readonly) MGSFragaria *fragaria;
 
 
 @end

--- a/MGSFragariaView.h
+++ b/MGSFragariaView.h
@@ -25,5 +25,16 @@
 /** Provides direct access to the view's instance of MGSFragaria. */
 @property (nonatomic, strong, readonly) MGSFragaria *fragaria;
 
+/** The same as in the protocol, but IBOutlet added. */
+@property (nonatomic, weak) IBOutlet id<SMLAutoCompleteDelegate> autoCompleteDelegate;
+
+/** The same as in the protocol, but IBOutlet added. */
+@property (nonatomic, weak) IBOutlet id<MGSBreakpointDelegate> breakpointDelegate;
+
+/** The same as in the protocol, but IBOutlet added. */
+@property (nonatomic, weak) IBOutlet id<MGSFragariaTextViewDelegate, MGSDragOperationDelegate> textViewDelegate;
+
+/** The same as in the protocol, but IBOutlet added. */
+@property (nonatomic, weak) IBOutlet id<SMLSyntaxColouringDelegate> syntaxColouringDelegate;
 
 @end

--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -17,7 +17,10 @@
 
 @interface MGSFragariaView ()
 
-@property (strong) MGSFragaria *fragaria;
+@property (nonatomic, strong, readwrite) MGSFragaria *fragaria;
+
+/* Protocol defines this as strong, but it's a reference, not a copy. */
+@property (nonatomic, strong, readwrite) SMLTextView *textView;
 
 @end
 
@@ -31,10 +34,10 @@
 #pragma mark - Initialization and Setup
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	initWithCoder:
-        called when unarchived from the nib linking directly.
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
+/*
+ * - initWithCoder:
+ *   Called when unarchived from a nib.
+ */
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
 	if ((self = [super initWithCoder:coder]))
@@ -50,10 +53,11 @@
 	return self;
 }
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	initWithFrame:
-        called when used in a framework.
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
+
+/*
+ * - initWithFrame:
+ *   Called when used in a framework.
+ */
 - (instancetype)initWithFrame:(NSRect)frameRect
 {
     if ((self = [super initWithFrame:frameRect]))
@@ -70,60 +74,46 @@
 }
 
 
-#pragma mark - Delegate Setters and Getters
+/*
+ * Note: while it would be trivial to bypass Fragaria's setters for most of
+ * these properties and use the system components properties directly, using
+ * the MGSFragaria properties directly provides some limited testing against
+ * MGSFragaria's interface. An extra message for a property setter is
+ * negligible.
+ * @todo: (jsd) MGSFragaria should use the MGSFragariaAPI, too, then these
+ *              accessors can access the component propery directly.
+ */
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	delegate
-		Expose the embedded NSTextView's delegate.
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setDelegate:(id<MGSFragariaTextViewDelegate>)delegate
-{
-	[self.fragaria setTextViewDelegate:delegate];
-}
-
-- (id<MGSFragariaTextViewDelegate>)delegate
-{
-	return self.fragaria.textViewDelegate;
-}
+#pragma mark - Accessing Fragaria's Views
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	breakPointDelegate
-		Expose Fregaria's <MGSBreakpointDelegate> delegate.
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setBreakPointDelegate:(id<MGSBreakpointDelegate>)breakPointDelegate
-{
-	[self.fragaria setBreakpointDelegate:breakPointDelegate];
-}
-
-- (id<MGSBreakpointDelegate>)breakPointDelegate
-{
-	return self.fragaria.breakpointDelegate;
-}
+/*
+ * @property textView
+ */
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	syntaxColoringDelegate
-		Expose Fregaria's <SMLSyntaxColouringDelegate> delegate.
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setSyntaxColoringDelegate:(id<SMLSyntaxColouringDelegate>)syntaxColoringDelegate
-{
-	[self.fragaria setSyntaxColouringDelegate:syntaxColoringDelegate];
-}
-
-- (id<SMLSyntaxColouringDelegate>)syntaxColoringDelegate
-{
-	return [self.fragaria syntaxColouringDelegate];
-}
+/*
+ * @property scrollView
+ */
 
 
-#pragma mark - Properties - Document Support
+/*
+ * @property gutterView
+ */
+
+ 
+/*
+ * @property syntaxColouring
+ */
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	string
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
+#pragma mark - Accessing Text Content
+
+
+/*
+ * @property string
+ */
 - (void)setString:(NSString *)string
 {
 	[self.fragaria setString:string];
@@ -135,69 +125,26 @@
 }
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	syntaxDefinitionName
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setSyntaxDefinitionName:(NSString *)syntaxDefinitionName
-{
-    self.fragaria.syntaxDefinitionName = syntaxDefinitionName;
-}
-
-- (NSString *)syntaxDefinitionName
-{
-    return self.fragaria.syntaxDefinitionName;
-}
+/*
+ * @property attributedStringWithTemporaryAttributesApplied
+ */
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	syntaxErrors
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setSyntaxErrors:(NSArray *)syntaxErrors
-{
-    self.fragaria.syntaxErrors = syntaxErrors;
-}
-
-- (NSArray *)syntaxErrors
-{
-    return self.fragaria.syntaxErrors;
-}
+#pragma mark - Creating Split Panels
 
 
-#pragma mark - Properties - Overall Appearance and Display
+/*
+ * - replaceTextStorage:
+ */
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	hasVerticalScroller
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setHasVerticalScroller:(BOOL)hasVerticalScroller
-{
-    [self.fragaria setHasVerticalScroller:hasVerticalScroller];
-}
-
-- (BOOL)hasVerticalScroller
-{
-    return [self.fragaria hasVerticalScroller];
-}
+#pragma mark - Configuring Syntax Highlighting
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	gutterMinimumWidth
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setGutterMinimumWidth:(NSUInteger)gutterMinimumWidth
-{
-    self.fragaria.minimumGutterWidth = gutterMinimumWidth;
-}
-
-- (NSUInteger)gutterMinimumWidth
-{
-    return self.fragaria.minimumGutterWidth;
-}
-
-
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	isSyntaxColoured
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setIsSyntaxColoured:(BOOL)syntaxColoured
+/*
+ * @property syntaxColoured
+ */
+- (void)setSyntaxColoured:(BOOL)syntaxColoured
 {
 	[self.fragaria setSyntaxColoured:syntaxColoured];
 }
@@ -208,37 +155,114 @@
 }
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	lineWrap
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setLineWrap:(BOOL)lineWrap
+/*
+ * @property syntaxDefinitionName
+ */
+- (void)setSyntaxDefinitionName:(NSString *)syntaxDefinitionName
 {
-    [self.fragaria setLineWrap:lineWrap];
+	self.fragaria.syntaxDefinitionName = syntaxDefinitionName;
 }
 
-- (BOOL)lineWrap
+- (NSString *)syntaxDefinitionName
 {
-    return [self.fragaria lineWrap];
-}
-
-
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	scrollElasticityDisabled
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setScrollElasticityDisabled:(BOOL)scrollElasticityDisabled
-{
-    [self.fragaria setScrollElasticityDisabled:scrollElasticityDisabled];
-}
-
-- (BOOL)scrollElasticityDisabled
-{
-    return [self.fragaria scrollElasticityDisabled];
+	return self.fragaria.syntaxDefinitionName;
 }
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	showsLineNumbers
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
+/*
+ * @property syntaxColouringDelegate
+ */
+- (void)setSyntaxColoringDelegate:(id<SMLSyntaxColouringDelegate>)syntaxColoringDelegate
+{
+	[self.fragaria setSyntaxColouringDelegate:syntaxColoringDelegate];
+}
+
+- (id<SMLSyntaxColouringDelegate>)syntaxColoringDelegate
+{
+	return [self.fragaria syntaxColouringDelegate];
+}
+
+
+/*
+ * @property BOOL coloursMultiLineStrings
+ */
+
+
+/*
+ * @property BOOL coloursOnlyUntilEndOfLine
+ */
+
+
+#pragma mark - Configuring Autocompletion
+
+
+/*
+ * @property autoCompleteDelegate
+ */
+
+
+/*
+ * @property double autoCompleteDelay
+ */
+
+ 
+/*
+ * @property BOOL autoCompleteEnabled
+ */
+
+ 
+/*
+ * @property BOOL autoCompleteWithKeywords
+ */
+
+
+#pragma mark - Highlighting the current line
+
+
+/*
+ * @property currentLineHighlightColour
+ */
+
+
+/*
+ * @property highlightsCurrentLine
+ */
+
+
+#pragma mark - Configuring the Gutter
+
+
+/*
+ * @property showsGutter
+ */
+- (void)setShowsGutter:(BOOL)showsGutter
+{
+	[self.fragaria setShowsGutter:showsGutter];
+}
+
+- (BOOL)showsGutter
+{
+	return [self.fragaria showsGutter];
+}
+
+
+/*
+ * @property minimumGutterWidth
+ */
+- (void)setMinimumWGutteridth:(NSUInteger)minimumGutterWidth
+{
+	self.fragaria.minimumGutterWidth = minimumGutterWidth;
+}
+
+- (CGFloat)minimumGutterWidth
+{
+	return self.fragaria.minimumGutterWidth;
+}
+
+
+/*
+ * @property showsLineNumbers
+ */
 - (void)setShowsLineNumbers:(BOOL)showsLineNumbers
 {
 	[self.fragaria setShowsLineNumbers:showsLineNumbers];
@@ -250,37 +274,9 @@
 }
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	showsGutter
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setShowsGutter:(BOOL)showsGutter
-{
-    [self.fragaria setShowsGutter:showsGutter];
-}
-
-- (BOOL)showsGutter
-{
-    return [self.fragaria showsGutter];
-}
-
-
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	showsWarningsInGutter
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setShowsWarningsInGutter:(BOOL)showsWarningsInGutter
-{
-    [self.fragaria setShowsSyntaxErrors:showsWarningsInGutter];
-}
-
-- (BOOL)showsWarningsInGutter
-{
-    return [self.fragaria showsSyntaxErrors];
-}
-
-
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	startingLineNumber
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
+/*
+ * @property startingLineNumber
+ */
 - (void)setStartingLineNumber:(NSUInteger)startingLineNumber
 {
 	[self.fragaria setStartingLineNumber:startingLineNumber];
@@ -292,42 +288,344 @@
 }
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	textFont
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
-- (void)setTextFont:(NSFont *)textFont
+/*
+ * @property gutterFont
+ */
+
+
+/*
+ * @property gutterTextColour
+ */
+
+
+#pragma mark - Showing Syntax Errors
+
+
+/*
+ * @property syntaxErrors
+ */
+- (void)setSyntaxErrors:(NSArray *)syntaxErrors
 {
-    self.fragaria.textFont = textFont;
+	self.fragaria.syntaxErrors = syntaxErrors;
 }
 
-- (NSFont *)textFont
+- (NSArray *)syntaxErrors
 {
-    return self.fragaria.textFont;
+	return self.fragaria.syntaxErrors;
 }
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	textInvisibleCharactersColour
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
+/*
+ * @property showsSyntaxErrors
+ */
+- (void)setShowsSyntaxErrors:(BOOL)showsSyntaxErrors
+{
+	[self.fragaria setShowsSyntaxErrors:showsSyntaxErrors];
+}
+
+- (BOOL)showsSyntaxErrors
+{
+	return [self.fragaria showsSyntaxErrors];
+}
+
+
+#pragma mark - Showing Breakpoints
+
+
+/*
+ * @property breakpointDelegate
+ */
+- (void)setBreakPointDelegate:(id<MGSBreakpointDelegate>)breakPointDelegate
+{
+	[self.fragaria setBreakpointDelegate:breakPointDelegate];
+}
+
+- (id<MGSBreakpointDelegate>)breakPointDelegate
+{
+	return self.fragaria.breakpointDelegate;
+}
+
+
+#pragma mark - Tabulation and Indentation
+
+
+/*
+ * @property tabWidth
+ */
+
+
+/*
+ * @property indentWidth
+ */
+
+
+/*
+ * @property indentWithSpaces
+ */
+
+
+/*
+ * @property useTabStops
+ */
+
+
+/*
+ * @property indentBracesAutomatically
+ */
+
+
+/*
+ * @property indentNewLinesAutomatically
+ */
+
+
+#pragma mark - Automatic Bracing
+
+
+/*
+ * @property insertClosingParenthesisAutomatically
+ */
+
+
+/*
+ * @property insertClosingBraceAutomatically
+ */
+
+
+/*
+ * @property showsMatchingBraces
+ */
+
+
+#pragma mark - Page Guide and Line Wrap
+
+
+/*
+ * @property pageGuideColumn
+ */
+
+
+/*
+ * @property showsPageGuide
+ */
+
+
+/*
+ * @property lineWrap
+ */
+- (void)setLineWrap:(BOOL)lineWrap
+{
+	[self.fragaria setLineWrap:lineWrap];
+}
+
+- (BOOL)lineWrap
+{
+	return [self.fragaria lineWrap];
+}
+
+
+#pragma mark - Showing Invisible Characters
+
+
+/*
+ * @property showsInvisibleCharacters
+ */
+
+
+/*
+ * @property textInvisibleCharactersColour
+ */
 - (void)setTextInvisibleCharactersColour:(NSColor *)textInvisibleCharactersColor
 {
-    self.fragaria.textInvisibleCharactersColour = textInvisibleCharactersColor;
+	self.fragaria.textInvisibleCharactersColour = textInvisibleCharactersColor;
 }
 
 - (NSColor *)textInvisibleCharactersColour
 {
-    return self.fragaria.textInvisibleCharactersColour;
+	return self.fragaria.textInvisibleCharactersColour;
 }
 
 
-/*–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*
-	goToLine
- *–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––*/
+#pragma mark - Configuring Text Appearance
+
+
+/*
+ * @property textColor
+ */
+
+
+/*
+ * @property backgroundColor
+ */
+
+
+/*
+ * @property textFont
+ */
+- (void)setTextFont:(NSFont *)textFont
+{
+	self.fragaria.textFont = textFont;
+}
+
+- (NSFont *)textFont
+{
+	return self.fragaria.textFont;
+}
+
+
+#pragma mark - Configuring Additional Text View Behavior
+
+
+/*
+ * @property textViewDelegate
+ */
+- (void)setTextViewDelegate:(id<MGSFragariaTextViewDelegate>)textViewDelegate
+{
+	[self.fragaria setTextViewDelegate:textViewDelegate];
+}
+
+- (id<MGSFragariaTextViewDelegate>)textViewDelegate
+{
+	return self.fragaria.textViewDelegate;
+}
+
+
+/*
+ * @property hasVerticalScroller
+ */
+- (void)setHasVerticalScroller:(BOOL)hasVerticalScroller
+{
+	[self.fragaria setHasVerticalScroller:hasVerticalScroller];
+}
+
+- (BOOL)hasVerticalScroller
+{
+	return [self.fragaria hasVerticalScroller];
+}
+
+
+/*
+ * @property insertionPointColor
+ */
+
+
+/*
+ * @property scrollElasticityDisabled
+ */
+- (void)setScrollElasticityDisabled:(BOOL)scrollElasticityDisabled
+{
+	[self.fragaria setScrollElasticityDisabled:scrollElasticityDisabled];
+}
+
+- (BOOL)scrollElasticityDisabled
+{
+	return [self.fragaria scrollElasticityDisabled];
+}
+
+
+/*
+ * - goToLine:centered:highlight
+ */
 - (void)goToLine:(NSInteger)lineToGoTo centered:(BOOL)centered highlight:(BOOL)highlight
 {
 	[self.fragaria goToLine:lineToGoTo centered:centered highlight:highlight];
 }
 
+
+#pragma mark - Syntax Highlighting Colours
+
+
+/*
+ * @property colourForAutocomplete
+ */
+
+
+/*
+ * @property colourForAttributes
+ */
+
+
+/*
+ * @property colourForCommands
+ */
+
+
+/*
+ * @property colourForComments
+ */
+
+
+/*
+ * @property colourForInstructions
+ */
+
+
+/*
+ * @property colourForKeywords
+ */
+
+
+/*
+ * @property colourForNumbers
+ */
+
+
+/*
+ * @property colourForStrings
+ */
+
+
+/*
+ * @property colourForVariables
+ */
+
+
+#pragma mark - Syntax Highlighter Colouring Options
+
+
+/*
+ * @property coloursAttributes
+ */
+
+
+/*
+ * @property coloursAutocomplete
+ */
+
+
+/*
+ * @property coloursCommands
+ */
+
+
+/*
+ * @property coloursComments
+ */
+
+
+/*
+ * @property coloursInstructions
+ */
+
+
+/*
+ * @property coloursKeywords
+ */
+
+
+/*
+ * @property coloursNumbers
+ */
+
+
+/*
+ * @property coloursStrings
+ */
+
+
+/*
+ * @property coloursVariables
+*/
 
 
 @end

--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -10,7 +10,7 @@
 //
 
 #import "MGSFragariaView.h"
-
+#import "SMLSyntaxColouring.h"
 
 #pragma mark - PRIVATE INTERFACE
 
@@ -784,46 +784,127 @@
 /*
  * @property colourForAutocomplete
  */
+- (void)setColourForAutocomplete:(NSColor *)colourForAutocomplete
+{
+    self.fragaria.syntaxColouring.colourForAutocomplete = colourForAutocomplete;
+}
+
+- (NSColor *)colourForAutocomplete
+{
+    return self.fragaria.syntaxColouring.colourForAutocomplete;
+}
 
 
 /*
  * @property colourForAttributes
  */
+- (void)setColourForAttributes:(NSColor *)colourForAttributes
+{
+    self.fragaria.syntaxColouring.colourForAttributes = colourForAttributes;
+}
+
+- (NSColor *)colourForAttributes
+{
+    return self.fragaria.syntaxColouring.colourForAttributes;
+}
 
 
 /*
  * @property colourForCommands
  */
+- (void)setColourForCommands:(NSColor *)colourForCommands
+{
+    self.fragaria.syntaxColouring.colourForCommands = colourForCommands;
+}
+
+- (NSColor *)colourForCommands
+{
+    return self.fragaria.syntaxColouring.colourForCommands;
+}
 
 
 /*
  * @property colourForComments
  */
+- (void)setColourForComments:(NSColor *)colourForComments
+{
+    self.fragaria.syntaxColouring.colourForComments = colourForComments;
+}
+
+- (NSColor *)colourForComments
+{
+    return self.fragaria.syntaxColouring.colourForComments;
+}
 
 
 /*
  * @property colourForInstructions
  */
+- (void)setColourForInstructions:(NSColor *)colourForInstructions
+{
+    self.fragaria.syntaxColouring.colourForInstructions = colourForInstructions;
+}
+
+- (NSColor *)colourForInstructions
+{
+    return self.fragaria.syntaxColouring.colourForInstructions;
+}
 
 
 /*
  * @property colourForKeywords
  */
+- (void)setColourForKeywords:(NSColor *)colourForKeywords
+{
+    self.fragaria.syntaxColouring.colourForKeywords = colourForKeywords;
+}
+
+- (NSColor *)colourForKeywords
+{
+    return self.fragaria.syntaxColouring.colourForKeywords;
+}
 
 
 /*
  * @property colourForNumbers
  */
+- (void)setColourForNumbers:(NSColor *)colourForNumbers
+{
+    self.fragaria.syntaxColouring.colourForNumbers = colourForNumbers;
+}
+
+- (NSColor *)colourForNumbers
+{
+    return self.fragaria.syntaxColouring.colourForNumbers;
+}
 
 
 /*
  * @property colourForStrings
  */
+- (void)setColourForStrings:(NSColor *)colourForStrings
+{
+    self.fragaria.syntaxColouring.colourForStrings = colourForStrings;
+}
+
+- (NSColor *)colourForStrings
+{
+    return self.fragaria.syntaxColouring.colourForStrings;
+}
 
 
 /*
  * @property colourForVariables
  */
+- (void)setColourForVariables:(NSColor *)colourForVariables
+{
+    self.fragaria.syntaxColouring.colourForVariables = colourForVariables;
+}
+
+- (NSColor *)colourForVariables
+{
+    return self.fragaria.syntaxColouring.colourForVariables;
+}
 
 
 #pragma mark - Syntax Highlighter Colouring Options
@@ -832,46 +913,126 @@
 /*
  * @property coloursAttributes
  */
+- (void)setColoursAttributes:(BOOL)coloursAttributes
+{
+    self.fragaria.syntaxColouring.coloursAttributes = coloursAttributes;
+}
 
+- (BOOL)coloursAttributes
+{
+    return self.fragaria.syntaxColouring.coloursAttributes;
+}
 
 /*
  * @property coloursAutocomplete
  */
+- (void)setColoursAutocomplete:(BOOL)coloursAutocomplete
+{
+    self.fragaria.syntaxColouring.coloursAutocomplete = coloursAutocomplete;
+}
+
+- (BOOL)coloursAutocomplete
+{
+    return self.fragaria.syntaxColouring.coloursAutocomplete;
+}
 
 
 /*
  * @property coloursCommands
  */
+- (void)setColoursCommands:(BOOL)coloursCommands
+{
+    self.fragaria.syntaxColouring.coloursCommands = coloursCommands;
+}
+
+- (BOOL)coloursCommands
+{
+    return self.fragaria.syntaxColouring.coloursCommands;
+}
 
 
 /*
  * @property coloursComments
  */
+- (void)setColoursComments:(BOOL)coloursComments
+{
+    self.fragaria.syntaxColouring.coloursComments = coloursComments;
+}
+
+- (BOOL)coloursComments
+{
+    return self.fragaria.syntaxColouring.coloursComments;
+}
 
 
 /*
  * @property coloursInstructions
  */
+- (void)setColoursInstructions:(BOOL)coloursInstructions
+{
+    self.fragaria.syntaxColouring.coloursInstructions = coloursInstructions;
+}
+
+- (BOOL)coloursInstructions
+{
+    return self.fragaria.syntaxColouring.coloursInstructions;
+}
 
 
 /*
  * @property coloursKeywords
  */
+- (void)setColoursKeywords:(BOOL)coloursKeywords
+{
+    self.fragaria.syntaxColouring.coloursKeywords = coloursKeywords;
+}
+
+- (BOOL)coloursKeywords
+{
+    return self.fragaria.syntaxColouring.coloursKeywords;
+}
 
 
 /*
  * @property coloursNumbers
  */
+- (void)setColoursNumbers:(BOOL)coloursNumbers
+{
+    self.fragaria.syntaxColouring.coloursNumbers = coloursNumbers;
+}
+
+- (BOOL)coloursNumbers
+{
+    return self.fragaria.syntaxColouring.coloursNumbers;
+}
 
 
 /*
  * @property coloursStrings
  */
+- (void)setColoursStrings:(BOOL)coloursStrings
+{
+    self.fragaria.syntaxColouring.coloursStrings = coloursStrings;
+}
+
+- (BOOL)coloursStrings
+{
+    return self.fragaria.syntaxColouring.coloursStrings;
+}
 
 
 /*
  * @property coloursVariables
 */
+- (void)setColoursVariables:(BOOL)coloursVariables
+{
+    self.fragaria.syntaxColouring.coloursVariables = coloursVariables;
+}
+
+- (BOOL)coloursVariables
+{
+    return self.fragaria.syntaxColouring.coloursVariables;
+}
 
 
 @end

--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -19,9 +19,6 @@
 
 @property (nonatomic, strong, readwrite) MGSFragaria *fragaria;
 
-/* Protocol defines this as strong, but it's a reference, not a copy. */
-@property (nonatomic, strong, readwrite) SMLTextView *textView;
-
 @end
 
 
@@ -29,6 +26,10 @@
 
 
 @implementation MGSFragariaView
+
+// Silence XCode warning, as it doesn't see the properties
+// are indeed implemented.
+@dynamic breakpointDelegate, syntaxColouringDelegate;
 
 
 #pragma mark - Initialization and Setup
@@ -48,7 +49,6 @@
 		   be honored.
 		 */
 		self.fragaria = [[MGSFragaria alloc] initWithView:self];
-        self.textView = self.fragaria.textView;
 	}
 	return self;
 }
@@ -68,7 +68,6 @@
 		   be honored.
 		 */
 		self.fragaria = [[MGSFragaria alloc] initWithView:self];
-        self.textView = self.fragaria.textView;
     }
     return self;
 }
@@ -91,21 +90,37 @@
 /*
  * @property textView
  */
+-(SMLTextView *)textView
+{
+    return self.fragaria.textView;
+}
 
 
 /*
  * @property scrollView
  */
+- (NSScrollView*)scrollView
+{
+    return self.fragaria.scrollView;
+}
 
 
 /*
  * @property gutterView
  */
+- (MGSLineNumberView *)gutterView
+{
+    return self.fragaria.gutterView;
+}
 
  
 /*
  * @property syntaxColouring
  */
+- (SMLSyntaxColouring *)syntaxColouring
+{
+    return self.fragaria.syntaxColouring;
+}
 
 
 #pragma mark - Accessing Text Content
@@ -116,18 +131,22 @@
  */
 - (void)setString:(NSString *)string
 {
-	[self.fragaria setString:string];
+	self.fragaria.string = string;
 }
 
 - (NSString *)string
 {
-	return [self.fragaria string];
+	return self.fragaria.string;
 }
 
 
 /*
  * @property attributedStringWithTemporaryAttributesApplied
  */
+- (NSAttributedString *)attributedStringWithTemporaryAttributesApplied
+{
+    return self.fragaria.attributedStringWithTemporaryAttributesApplied;
+}
 
 
 #pragma mark - Creating Split Panels
@@ -136,6 +155,9 @@
 /*
  * - replaceTextStorage:
  */
+- (void)replaceTextStorage:(NSTextStorage *)textStorage{
+    [self.fragaria replaceTextStorage:textStorage];
+}
 
 
 #pragma mark - Configuring Syntax Highlighting
@@ -172,25 +194,43 @@
 /*
  * @property syntaxColouringDelegate
  */
-- (void)setSyntaxColoringDelegate:(id<SMLSyntaxColouringDelegate>)syntaxColoringDelegate
+- (void)setSyntaxColouringDelegate:(id<SMLSyntaxColouringDelegate>)syntaxColouringDelegate
 {
-	[self.fragaria setSyntaxColouringDelegate:syntaxColoringDelegate];
+    self.fragaria.syntaxColouringDelegate = syntaxColouringDelegate;
 }
 
 - (id<SMLSyntaxColouringDelegate>)syntaxColoringDelegate
 {
-	return [self.fragaria syntaxColouringDelegate];
+    return self.fragaria.syntaxColouringDelegate;
 }
 
 
 /*
  * @property BOOL coloursMultiLineStrings
  */
+- (void)setColoursMultiLineStrings:(BOOL)coloursMultiLineStrings
+{
+    self.fragaria.coloursMultiLineStrings = coloursMultiLineStrings;
+}
+
+- (BOOL)coloursMultiLineStrings
+{
+    return self.fragaria.coloursMultiLineStrings;
+}
 
 
 /*
  * @property BOOL coloursOnlyUntilEndOfLine
  */
+- (void)setColoursOnlyUntilEndOfLine:(BOOL)coloursOnlyUntilEndOfLine
+{
+    self.fragaria.coloursOnlyUntilEndOfLine = coloursOnlyUntilEndOfLine;
+}
+
+- (BOOL)coloursOnlyUntilEndOfLine
+{
+    return self.fragaria.coloursOnlyUntilEndOfLine;
+}
 
 
 #pragma mark - Configuring Autocompletion
@@ -199,21 +239,57 @@
 /*
  * @property autoCompleteDelegate
  */
+- (void)setAutoCompleteDelegate:(id<SMLAutoCompleteDelegate>)autoCompleteDelegate
+{
+    self.fragaria.autoCompleteDelegate = autoCompleteDelegate;
+}
+
+- (id<SMLAutoCompleteDelegate>)autoCompleteDelegate
+{
+    return self.fragaria.autoCompleteDelegate;
+}
 
 
 /*
  * @property double autoCompleteDelay
  */
+- (void)setAutoCompleteDelay:(double)autoCompleteDelay
+{
+    self.fragaria.autoCompleteDelay = autoCompleteDelay;
+}
+
+- (double)autoCompleteDelay
+{
+    return self.fragaria.autoCompleteDelay;
+}
 
  
 /*
  * @property BOOL autoCompleteEnabled
  */
+- (void)setAutoCompleteEnabled:(BOOL)autoCompleteEnabled
+{
+    self.fragaria.autoCompleteEnabled = autoCompleteEnabled;
+}
+
+- (BOOL)autoCompleteEnabled
+{
+    return self.fragaria.autoCompleteEnabled;
+}
 
  
 /*
  * @property BOOL autoCompleteWithKeywords
  */
+- (void)setAutoCompleteWithKeywords:(BOOL)autoCompleteWithKeywords
+{
+    self.fragaria.autoCompleteWithKeywords = autoCompleteWithKeywords;
+}
+
+- (BOOL)autoCompleteWithKeywords
+{
+    return self.fragaria.autoCompleteWithKeywords;
+}
 
 
 #pragma mark - Highlighting the current line
@@ -222,11 +298,29 @@
 /*
  * @property currentLineHighlightColour
  */
+- (void)setCurrentLineHighlightColour:(NSColor *)currentLineHighlightColour
+{
+    self.fragaria.currentLineHighlightColour = currentLineHighlightColour;
+}
+
+- (NSColor *)currentLineHighlightColour
+{
+    return self.fragaria.currentLineHighlightColour;
+}
 
 
 /*
  * @property highlightsCurrentLine
  */
+- (void)setHighlightsCurrentLine:(BOOL)highlightsCurrentLine
+{
+    self.fragaria.highlightsCurrentLine = highlightsCurrentLine;
+}
+
+- (BOOL)highlightsCurrentLine
+{
+    return self.fragaria.highlightsCurrentLine;
+}
 
 
 #pragma mark - Configuring the Gutter
@@ -249,7 +343,7 @@
 /*
  * @property minimumGutterWidth
  */
-- (void)setMinimumWGutteridth:(NSUInteger)minimumGutterWidth
+- (void)setMinimumGutterWidth:(CGFloat)minimumGutterWidth
 {
 	self.fragaria.minimumGutterWidth = minimumGutterWidth;
 }
@@ -291,11 +385,28 @@
 /*
  * @property gutterFont
  */
+- (void)setGutterFont:(NSFont *)gutterFont
+{
+    self.fragaria.gutterFont = gutterFont;
+}
 
+- (NSFont *)gutterFont
+{
+    return self.fragaria.gutterFont;
+}
 
 /*
  * @property gutterTextColour
  */
+- (void)setGutterTextColour:(NSColor *)gutterTextColour
+{
+    self.fragaria.gutterTextColour = gutterTextColour;
+}
+
+- (NSColor *)gutterTextColour
+{
+    return self.fragaria.gutterTextColour;
+}
 
 
 #pragma mark - Showing Syntax Errors
@@ -335,9 +446,9 @@
 /*
  * @property breakpointDelegate
  */
-- (void)setBreakPointDelegate:(id<MGSBreakpointDelegate>)breakPointDelegate
+- (void)setBreakpointDelegate:(id<MGSBreakpointDelegate>)breakpointDelegate
 {
-	[self.fragaria setBreakpointDelegate:breakPointDelegate];
+	[self.fragaria setBreakpointDelegate:breakpointDelegate];
 }
 
 - (id<MGSBreakpointDelegate>)breakPointDelegate
@@ -352,31 +463,85 @@
 /*
  * @property tabWidth
  */
+- (void)setTabWidth:(NSInteger)tabWidth
+{
+    self.fragaria.tabWidth = tabWidth;
+}
+
+- (NSInteger)tabWidth
+{
+    return self.fragaria.tabWidth;
+}
 
 
 /*
  * @property indentWidth
  */
+- (void)setIndentWidth:(NSUInteger)indentWidth
+{
+    self.fragaria.indentWidth = indentWidth;
+}
+
+- (NSUInteger)indentWidth
+{
+    return self.fragaria.indentWidth;
+}
 
 
 /*
  * @property indentWithSpaces
  */
+- (void)setIndentWithSpaces:(BOOL)indentWithSpaces
+{
+    self.fragaria.indentWithSpaces = indentWithSpaces;
+}
+
+- (BOOL)indentWithSpaces
+{
+    return self.fragaria.indentWithSpaces;
+}
 
 
 /*
  * @property useTabStops
  */
+- (void)setUseTabStops:(BOOL)useTabStops
+{
+    self.fragaria.useTabStops = useTabStops;
+}
+
+- (BOOL)useTabStops
+{
+    return self.fragaria.useTabStops;
+}
 
 
 /*
  * @property indentBracesAutomatically
  */
+- (void)setIndentBracesAutomatically:(BOOL)indentBracesAutomatically
+{
+    self.fragaria.indentBracesAutomatically = indentBracesAutomatically;
+}
+
+- (BOOL)indentBracesAutomatically
+{
+    return self.fragaria.indentBracesAutomatically;
+}
 
 
 /*
  * @property indentNewLinesAutomatically
  */
+- (void)setIndentNewLinesAutomatically:(BOOL)indentNewLinesAutomatically
+{
+    self.fragaria.indentNewLinesAutomatically = indentNewLinesAutomatically;
+}
+
+- (BOOL)indentNewLinesAutomatically
+{
+    return self.fragaria.indentNewLinesAutomatically;
+}
 
 
 #pragma mark - Automatic Bracing
@@ -385,16 +550,43 @@
 /*
  * @property insertClosingParenthesisAutomatically
  */
+- (void)setInsertClosingParenthesisAutomatically:(BOOL)insertClosingParenthesisAutomatically
+{
+    self.fragaria.insertClosingParenthesisAutomatically = insertClosingParenthesisAutomatically;
+}
+
+- (BOOL)insertClosingParenthesisAutomatically
+{
+    return self.fragaria.insertClosingParenthesisAutomatically;
+}
 
 
 /*
  * @property insertClosingBraceAutomatically
  */
+- (void)setInsertClosingBraceAutomatically:(BOOL)insertClosingBraceAutomatically
+{
+    self.fragaria.insertClosingBraceAutomatically = insertClosingBraceAutomatically;
+}
+
+- (BOOL)insertClosingBraceAutomatically
+{
+    return self.fragaria.insertClosingBraceAutomatically;
+}
 
 
 /*
  * @property showsMatchingBraces
  */
+- (void)setShowsMatchingBraces:(BOOL)showsMatchingBraces
+{
+    self.fragaria.showsMatchingBraces = showsMatchingBraces;
+}
+
+- (BOOL)showsMatchingBraces
+{
+    return self.fragaria.showsMatchingBraces;
+}
 
 
 #pragma mark - Page Guide and Line Wrap
@@ -403,11 +595,29 @@
 /*
  * @property pageGuideColumn
  */
+- (void)setPageGuideColumn:(NSInteger)pageGuideColumn
+{
+    self.fragaria.pageGuideColumn = pageGuideColumn;
+}
+
+- (NSInteger)pageGuideColumn
+{
+    return self.fragaria.pageGuideColumn;
+}
 
 
 /*
  * @property showsPageGuide
  */
+-(void)setShowsPageGuide:(BOOL)showsPageGuide
+{
+    self.fragaria.showsPageGuide = showsPageGuide;
+}
+
+- (BOOL)showsPageGuide
+{
+    return self.fragaria.showsPageGuide;
+}
 
 
 /*
@@ -430,6 +640,15 @@
 /*
  * @property showsInvisibleCharacters
  */
+- (void)setShowsInvisibleCharacters:(BOOL)showsInvisibleCharacters
+{
+    self.fragaria.showsInvisibleCharacters = showsInvisibleCharacters;
+}
+
+- (BOOL)showsInvisibleCharacters
+{
+    return self.fragaria.showsInvisibleCharacters;
+}
 
 
 /*
@@ -452,11 +671,29 @@
 /*
  * @property textColor
  */
+- (void)setTextColor:(NSColor *)textColor
+{
+    self.fragaria.textColor = textColor;
+}
+
+- (NSColor *)textColor
+{
+    return self.fragaria.textColor;
+}
 
 
 /*
  * @property backgroundColor
  */
+- (void)setBackgroundColor:(NSColor *)backgroundColor
+{
+    self.fragaria.backgroundColor = backgroundColor;
+}
+
+- (NSColor *)backgroundColor
+{
+    return self.fragaria.backgroundColor;
+}
 
 
 /*
@@ -479,12 +716,12 @@
 /*
  * @property textViewDelegate
  */
-- (void)setTextViewDelegate:(id<MGSFragariaTextViewDelegate>)textViewDelegate
+- (void)setTextViewDelegate:(id<MGSFragariaTextViewDelegate, MGSDragOperationDelegate>)textViewDelegate
 {
 	[self.fragaria setTextViewDelegate:textViewDelegate];
 }
 
-- (id<MGSFragariaTextViewDelegate>)textViewDelegate
+- (id<MGSFragariaTextViewDelegate, MGSDragOperationDelegate>)textViewDelegate
 {
 	return self.fragaria.textViewDelegate;
 }
@@ -507,6 +744,15 @@
 /*
  * @property insertionPointColor
  */
+- (void)setInsertionPointColor:(NSColor *)insertionPointColor
+{
+    self.fragaria.insertionPointColor = insertionPointColor;
+}
+
+- (NSColor *)insertionPointColor
+{
+    return self.fragaria.insertionPointColor;
+}
 
 
 /*


### PR DESCRIPTION
I cleaned up MGSFragariaView considerably by making it match MGSFragaria exactly. I did this by copying the pertinent properties from MGSFragaria.h directly into a new protocol (MGSFragariaAPI), and implementing that protocol in the MGSFragariaView. This seems to be exactly what protocols are for, and the protocol can be useful for other things.

Since none of the the properties are synthesized some of the protocol declarations that are mismatched (e.g., CGFloat in stead of assign) shouldn't generate ivars.

I did _not_ take the step of simply replacing the declarations in MGSFragaria by adopting the protocol, although this would be a logical action if you accept having a protocol.

I defined all of the SMLSyntaxColouring colours as optional, but did implement them in MGSFragariaView as I plan to make them bindings compatible per #56.

Right now all of the implementation of MGSFragaria's properties in MGSFragariaView are done using the topmost property of MGSFragaria. This should avoid having to write a long test case and will catch any changes made to property names in MGSFragaria. Of course if MGSFragaria uses the protocol, then I will make changes to access the lower-level object instances directly (probably premature or unnecessary optimization, but oh well).
