### PR TITLE
Properties coordinator/controller class

### DIFF
--- a/Fragaria.xcodeproj/project.pbxproj
+++ b/Fragaria.xcodeproj/project.pbxproj
@@ -89,6 +89,16 @@
 		D034C81C1A9984A1003D3A41 /* PrefsFontsAndColorsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D034C8191A9984A1003D3A41 /* PrefsFontsAndColorsViewController.m */; };
 		D034C81D1A9984A1003D3A41 /* PrefsTextEditingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D034C81B1A9984A1003D3A41 /* PrefsTextEditingViewController.m */; };
 		D04A0DF81AAEAD7C00667E4D /* MGSFragariaAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = D04A0DF71AAEAD7C00667E4D /* MGSFragariaAPI.h */; };
+		D071881C1AB322650073493A /* MGSUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = D07188161AB322650073493A /* MGSUserDefaults.h */; };
+		D071881D1AB322650073493A /* MGSUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = D07188171AB322650073493A /* MGSUserDefaults.m */; };
+		D071881E1AB322650073493A /* MGSUserDefaultsController.h in Headers */ = {isa = PBXBuildFile; fileRef = D07188181AB322650073493A /* MGSUserDefaultsController.h */; };
+		D071881F1AB322650073493A /* MGSUserDefaultsController.m in Sources */ = {isa = PBXBuildFile; fileRef = D07188191AB322650073493A /* MGSUserDefaultsController.m */; };
+		D07188201AB322650073493A /* MGSUserDefaultsDefinitions.h in Headers */ = {isa = PBXBuildFile; fileRef = D071881A1AB322650073493A /* MGSUserDefaultsDefinitions.h */; };
+		D07188211AB322650073493A /* MGSUserDefaultsDefinitions.m in Sources */ = {isa = PBXBuildFile; fileRef = D071881B1AB322650073493A /* MGSUserDefaultsDefinitions.m */; };
+		D07188271AB3228B0073493A /* MGSUserDefaultsControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D07188221AB3228B0073493A /* MGSUserDefaultsControllerTests.m */; };
+		D07188281AB3228B0073493A /* MGSUserDefaultsDefinitionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D07188231AB3228B0073493A /* MGSUserDefaultsDefinitionsTests.m */; };
+		D07188291AB3228B0073493A /* MGSUserDefaultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D07188241AB3228B0073493A /* MGSUserDefaultsTests.m */; };
+		D071882A1AB3228B0073493A /* MGSUserDefaultsUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = D07188261AB3228B0073493A /* MGSUserDefaultsUtilities.m */; };
 		D08359DB1A9F0446001B7B50 /* FeaturesWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = D08359D91A9F0446001B7B50 /* FeaturesWindowController.m */; };
 		D08359E11AA0875E001B7B50 /* MGSPreferencesObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = D08359DE1AA0875E001B7B50 /* MGSPreferencesObserver.m */; };
 		D0AB50F01A91CDC200A6DF58 /* SMLSyntaxErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AB50EF1A91CDC200A6DF58 /* SMLSyntaxErrorTests.m */; };
@@ -260,6 +270,17 @@
 		D034C81A1A9984A1003D3A41 /* PrefsTextEditingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PrefsTextEditingViewController.h; path = Applications/MGSFragariaView/PrefsTextEditingViewController.h; sourceTree = "<group>"; };
 		D034C81B1A9984A1003D3A41 /* PrefsTextEditingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PrefsTextEditingViewController.m; path = Applications/MGSFragariaView/PrefsTextEditingViewController.m; sourceTree = "<group>"; };
 		D04A0DF71AAEAD7C00667E4D /* MGSFragariaAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSFragariaAPI.h; sourceTree = "<group>"; };
+		D07188161AB322650073493A /* MGSUserDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSUserDefaults.h; sourceTree = "<group>"; };
+		D07188171AB322650073493A /* MGSUserDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSUserDefaults.m; sourceTree = "<group>"; };
+		D07188181AB322650073493A /* MGSUserDefaultsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSUserDefaultsController.h; sourceTree = "<group>"; };
+		D07188191AB322650073493A /* MGSUserDefaultsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSUserDefaultsController.m; sourceTree = "<group>"; };
+		D071881A1AB322650073493A /* MGSUserDefaultsDefinitions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSUserDefaultsDefinitions.h; sourceTree = "<group>"; };
+		D071881B1AB322650073493A /* MGSUserDefaultsDefinitions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSUserDefaultsDefinitions.m; sourceTree = "<group>"; };
+		D07188221AB3228B0073493A /* MGSUserDefaultsControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSUserDefaultsControllerTests.m; sourceTree = "<group>"; };
+		D07188231AB3228B0073493A /* MGSUserDefaultsDefinitionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSUserDefaultsDefinitionsTests.m; sourceTree = "<group>"; };
+		D07188241AB3228B0073493A /* MGSUserDefaultsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSUserDefaultsTests.m; sourceTree = "<group>"; };
+		D07188251AB3228B0073493A /* MGSUserDefaultsUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSUserDefaultsUtilities.h; sourceTree = "<group>"; };
+		D07188261AB3228B0073493A /* MGSUserDefaultsUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSUserDefaultsUtilities.m; sourceTree = "<group>"; };
 		D08359D81A9F0446001B7B50 /* FeaturesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FeaturesWindowController.h; path = Applications/MGSFragariaView/FeaturesWindowController.h; sourceTree = "<group>"; };
 		D08359D91A9F0446001B7B50 /* FeaturesWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FeaturesWindowController.m; path = Applications/MGSFragariaView/FeaturesWindowController.m; sourceTree = "<group>"; };
 		D08359DD1AA0875E001B7B50 /* MGSPreferencesObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSPreferencesObserver.h; sourceTree = "<group>"; };
@@ -595,6 +616,7 @@
 				01BB1BEC1A7962C7006C0056 /* Text View Components */,
 				01BB1BEB1A79620E006C0056 /* Text Editing UI */,
 				01BB1BEA1A795EFD006C0056 /* Preferences */,
+				D07188151AB3223B0073493A /* Properties Coordinator */,
 			);
 			name = Fragaria;
 			sourceTree = "<group>";
@@ -609,6 +631,19 @@
 			);
 			name = MASPreferences;
 			path = Applications/MGSFragariaView/MASPreferences;
+			sourceTree = "<group>";
+		};
+		D07188151AB3223B0073493A /* Properties Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				D071881A1AB322650073493A /* MGSUserDefaultsDefinitions.h */,
+				D071881B1AB322650073493A /* MGSUserDefaultsDefinitions.m */,
+				D07188181AB322650073493A /* MGSUserDefaultsController.h */,
+				D07188191AB322650073493A /* MGSUserDefaultsController.m */,
+				D07188161AB322650073493A /* MGSUserDefaults.h */,
+				D07188171AB322650073493A /* MGSUserDefaults.m */,
+			);
+			name = "Properties Coordinator";
 			sourceTree = "<group>";
 		};
 		D0E521001A90B899005CB80B /* MGSFragariaView */ = {
@@ -654,6 +689,11 @@
 		D0E5210E1A90E34F005CB80B /* MGSFragaria Tests */ = {
 			isa = PBXGroup;
 			children = (
+				D07188221AB3228B0073493A /* MGSUserDefaultsControllerTests.m */,
+				D07188231AB3228B0073493A /* MGSUserDefaultsDefinitionsTests.m */,
+				D07188241AB3228B0073493A /* MGSUserDefaultsTests.m */,
+				D07188251AB3228B0073493A /* MGSUserDefaultsUtilities.h */,
+				D07188261AB3228B0073493A /* MGSUserDefaultsUtilities.m */,
 				D01F51701AAF1D35006A3A90 /* MGSFragariaViewTests.m */,
 				D0E521071A90E307005CB80B /* MGSSyntaxErrorControllerTests.m */,
 				D0AB50EF1A91CDC200A6DF58 /* SMLSyntaxErrorTests.m */,
@@ -683,6 +723,7 @@
 				E3CF4B7916E6927300C27B5C /* MGSBreakpointDelegate.h in Headers */,
 				0191FA7D1A881F6E0099B50D /* MGSDragOperationDelegate.h in Headers */,
 				ABC578E91603D6000040B3FB /* MGSFragariaFontsAndColoursPrefsViewController.h in Headers */,
+				D07188201AB322650073493A /* MGSUserDefaultsDefinitions.h in Headers */,
 				AB257FE2129B1CE300A3FF76 /* MGSFragariaPreferences.h in Headers */,
 				ABE25D0A1635CA7C00F23718 /* MGSFragariaPrefsViewController.h in Headers */,
 				ABC578ED1603D7ED0040B3FB /* MGSFragariaTextEditingPrefsViewController.h in Headers */,
@@ -690,8 +731,10 @@
 				AB257FE4129B1CE300A3FF76 /* MGSTextMenuController.h in Headers */,
 				AB257FCE129B1BF500A3FF76 /* SMLTextView.h in Headers */,
 				E3D4B2771714D89700BB2CC6 /* SMLSyntaxError.h in Headers */,
+				D071881E1AB322650073493A /* MGSUserDefaultsController.h in Headers */,
 				D0C146751A871A0B00DDE90A /* MGSFragariaView.h in Headers */,
 				017FD58A1A7A992700B305FB /* MGSLineNumberView.h in Headers */,
+				D071881C1AB322650073493A /* MGSUserDefaults.h in Headers */,
 				E373BF131718A64700D71602 /* SMLAutoCompleteDelegate.h in Headers */,
 				D04A0DF81AAEAD7C00667E4D /* MGSFragariaAPI.h in Headers */,
 				AB8387AA171B4505004408F4 /* SMLSyntaxColouringDelegate.h in Headers */,
@@ -942,6 +985,9 @@
 				D08359E11AA0875E001B7B50 /* MGSPreferencesObserver.m in Sources */,
 				ABC578EE1603D7ED0040B3FB /* MGSFragariaTextEditingPrefsViewController.m in Sources */,
 				D0C146761A871A0B00DDE90A /* MGSFragariaView.m in Sources */,
+				D071881D1AB322650073493A /* MGSUserDefaults.m in Sources */,
+				D07188211AB322650073493A /* MGSUserDefaultsDefinitions.m in Sources */,
+				D071881F1AB322650073493A /* MGSUserDefaultsController.m in Sources */,
 				ABC5799816047B4E0040B3FB /* FRAFontTransformer.m in Sources */,
 				ABE25D0B1635CA7C00F23718 /* MGSFragariaPrefsViewController.m in Sources */,
 				0191FA821A8829930099B50D /* SMLTextView+MGSTextActions.m in Sources */,
@@ -979,8 +1025,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D07188271AB3228B0073493A /* MGSUserDefaultsControllerTests.m in Sources */,
 				D0AB50F01A91CDC200A6DF58 /* SMLSyntaxErrorTests.m in Sources */,
 				D0E5211A1A90E399005CB80B /* MGSSyntaxErrorControllerTests.m in Sources */,
+				D07188281AB3228B0073493A /* MGSUserDefaultsDefinitionsTests.m in Sources */,
+				D071882A1AB3228B0073493A /* MGSUserDefaultsUtilities.m in Sources */,
+				D07188291AB3228B0073493A /* MGSUserDefaultsTests.m in Sources */,
 				D01F51721AAF1D35006A3A90 /* MGSFragariaViewTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MGSFragaria Tests/MGSUserDefaultsControllerTests.m
+++ b/MGSFragaria Tests/MGSUserDefaultsControllerTests.m
@@ -1,0 +1,308 @@
+//
+//  MGSUserDefaultsControllerTests.m
+//  Fragaria
+//
+//  Created by Jim Derry on 3/11/15.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+#import <XCTest/XCTest.h>
+#import "MGSUserDefaultsDefinitions.h"
+#import "MGSUserDefaultsController.h"
+#import "MGSUserDefaults.h"
+#import "MGSFragariaView.h"
+
+
+/**
+ *  Adds some basic tests for MGSUserDefaultsController.
+ **/
+@interface MGSUserDefaultsControllerTests : XCTestCase
+
+@property MGSFragariaView *view1;
+@property MGSFragariaView *view2;
+
+@property NSMutableDictionary *dict1;
+@property NSMutableDictionary *dict2;
+
+@end
+
+@implementation MGSUserDefaultsControllerTests
+
+
+/*
+ * - setUp
+ *   Make some MGSFragariaView instances available for use.
+ */
+- (void)setUp
+{
+	[super setUp];
+	
+	self.view1 = [[MGSFragariaView alloc] initWithFrame:NSMakeRect(1.0, 1.0, 1.0, 1.0)];
+	self.view2 = [[MGSFragariaView alloc] initWithFrame:NSMakeRect(1.0, 1.0, 1.0, 1.0)];
+	
+	self.dict1 = [NSMutableDictionary dictionaryWithDictionary:@{ @"name" : @"jim" }];
+	self.dict2 = [NSMutableDictionary dictionaryWithDictionary:@{ @"name" : @"john" }];
+}
+
+
+/*
+ * - tearDown
+ *   Cleanup after every test to ensure virgin instances.
+ */
+- (void)tearDown
+{
+	[super tearDown];
+}
+
+
+/*
+ *  - test_binding_dictionaries
+ *    Test our assumption that two bound dictionaries' values will
+ *    stay in sync. This test works, so it's a useful reference, but
+ *    it's odd that binding to the dictionary in NSUserDefaultsController
+ *    fails.
+ */
+- (void)test_binding_dictionaries
+{
+    NSString *result1, *result2, *expect1;
+
+    [self bind:@"dict1" toObject:self withKeyPath:@"dict2" options:nil];
+    result1 = self.dict1[@"name"];
+    result2 = self.dict1[@"name"];
+    XCTAssert([result1 isEqualToString:result2]);
+
+    expect1 = @"jack";
+    self.dict1[@"name"] = expect1;
+    result1 = self.dict1[@"name"];
+    result2 = self.dict1[@"name"];
+    XCTAssert([result1 isEqualToString:expect1] && [result2 isEqualToString:expect1]);
+
+    expect1 = @"joseph";
+    self.dict1[@"name"] = expect1;
+    result1 = self.dict1[@"name"];
+    result2 = self.dict1[@"name"];
+    XCTAssert([result1 isEqualToString:expect1] && [result2 isEqualToString:expect1]);
+}
+
+
+/*
+ * - test_sharedControllers_groupID
+ *   Check that the shared controllers are indeed separate instances, and are
+ *   accessible.
+ */
+- (void)test_sharedControllers_groupID
+{
+	NSString *result1, *result2, *result3;
+	
+	NSString *expect1 = @"TopmostView";
+	NSString *expect2 = @"SomeOtherView";
+	NSString *expect3 = MGSUSERDEFAULTS_GLOBAL_ID;
+	
+	
+	result1 = [[MGSUserDefaultsController sharedControllerForGroupID:expect1] groupID];
+	result2 = [[MGSUserDefaultsController sharedControllerForGroupID:expect2] groupID];
+	result3 = [[MGSUserDefaultsController sharedController] groupID];
+	
+	XCTAssert([result1 isEqualToString:expect1]);
+	XCTAssert([result2 isEqualToString:expect2]);
+	XCTAssert([result3 isEqualToString:expect3]);
+}
+
+
+/*
+ * - test_sharedController_managedInstances_is_readonly
+ *   Ensure that managedInstances is read-only for sharedController.
+ */
+- (void)test_sharedController_managedInstances_is_readonly
+{
+	NSSet *instances = [NSSet setWithObject:self.view1];
+	
+	BOOL pass = NO;
+	@try {
+		// Yes, you SHOULD see an assertion failure in the log.
+		[MGSUserDefaultsController sharedController].managedInstances = instances;
+	}
+	@catch (NSException *exception){
+		pass = YES;
+	}
+	@finally {
+		XCTAssert(pass);
+	}
+	
+}
+
+
+/*
+ * - test_instances_share_property_values
+ *   Demonstrate that when instances are assigned to a groupID:
+ *   - They take each others value.
+ *   - `values` takes their value.
+ *   - Changes in `values` applies to the instances.
+ */
+- (void)test_instances_share_property_values
+{
+	NSUInteger expect1 = arc4random_uniform(100) + 1;
+	NSUInteger expect2 = arc4random_uniform(100) + 1;
+	NSUInteger result1, result2;
+	
+	MGSUserDefaultsController *controller = [MGSUserDefaultsController sharedControllerForGroupID:@"UnitTest"];
+	NSSet *instances = [NSSet setWithArray:@[self.view1, self.view2]];
+	
+	
+	self.view1.startingLineNumber = expect1;
+	self.view2.startingLineNumber = expect2;
+	
+	// Prove they are independent:
+	XCTAssert(self.view1.startingLineNumber == expect1 && self.view2.startingLineNumber == expect2);
+	
+	// Add them to a group and then test.
+	controller.managedInstances = instances;
+	controller.managedProperties = [NSSet setWithArray:@[ @"startingLineNumber" ]];
+	result1 = self.view1.startingLineNumber;
+	result2 = self.view2.startingLineNumber;
+	// We don't know the initial value, but they should now be equal.
+	XCTAssert( result1 == result2 );
+	
+	// If we set one of them, then the storage and other one should update, too.
+	self.view1.startingLineNumber = expect1;
+	result1 = self.view2.startingLineNumber;
+	result2 = [[controller.values valueForKey:@"startingLineNumber"] unsignedIntegerValue];
+	XCTAssert(result1 == expect1 && result2 == expect1);
+
+	// And of course if we set the values, it should update both properties.
+    [controller.values setValue:@(expect2) forKey:@"startingLineNumber"];
+	result1 = self.view1.startingLineNumber;
+	result2 = self.view2.startingLineNumber;
+	XCTAssert(result1 == expect2 && result2 == expect2);
+}
+
+
+/*
+ * - test_persistance_changes
+ *   Demonstrate:
+ *   - When persistance is turned ON, the defaults values update to the 
+ *     current value.
+ *   - When persistance is turned OFF, the current value is updated with the 
+ *     defaults value.
+ */
+- (void)test_persistance_changes
+{
+	NSUInteger expect;
+	NSUInteger result1, result2, result3;
+	
+	MGSUserDefaultsController *controller = [MGSUserDefaultsController sharedControllerForGroupID:@"UnitTest"];
+	MGSUserDefaults *defaults = [MGSUserDefaults sharedUserDefaultsForGroupID:@"UnitTest"];
+	NSSet *instances = [NSSet setWithArray:@[self.view1, self.view2]];
+
+	controller.managedInstances = instances;
+	controller.managedProperties = [NSSet setWithArray:@[ @"startingLineNumber" ]];
+
+	
+	// Setting defaults via the controller updates the instances:
+	expect = arc4random_uniform(100) + 1;
+	[controller.values setValue:@(expect) forKey:@"startingLineNumber"];
+	result1 = self.view1.startingLineNumber;
+	result2 = self.view2.startingLineNumber;
+	XCTAssert(result1 == expect && result2 == expect);
+	
+	// Turn ON persistence. Does defaults take the correct value now?
+	expect = arc4random_uniform(100) + 1;
+    [controller.values setValue:@(expect) forKey:@"startingLineNumber"];
+	controller.persistent = YES;
+	result1 = [defaults integerForKey:@"startingLineNumber"];
+	result2 = self.view1.startingLineNumber;
+	XCTAssert(result1 == expect && result2 == expect);
+
+	// Now that we have persistance, if we set the controller, will
+	// all of the views and defaults take the values, too?
+	expect = arc4random_uniform(100) + 1;
+    [controller.values setValue:@(expect) forKey:@"startingLineNumber"];
+	result1 = self.view1.startingLineNumber;
+	result2 = self.view2.startingLineNumber;
+	result3 = [defaults integerForKey:@"startingLineNumber"];
+	XCTAssert(result1 == expect && result2 == expect && result3 == expect);
+	
+    // Setting a property should reflect in defaults and the other instance.
+	expect = arc4random_uniform(100) + 1;
+	self.view1.startingLineNumber = expect;
+	result1 = [defaults integerForKey:@"startingLineNumber"];
+	result2 = self.view2.startingLineNumber;
+	XCTAssert(result1 == expect && result2 == expect);
+
+	// Does setting the user defaults change the instances?
+	expect = arc4random_uniform(100) + 1;
+	[defaults setInteger:expect forKey:@"startingLineNumber"];
+	result1 = self.view1.startingLineNumber;
+	result2 = self.view2.startingLineNumber;
+	XCTAssert(result1 == expect && result2 == expect);
+
+    // Now turn off persistence and ensure that:
+    // - setting the controller updates views, but not defaults.
+    expect = arc4random_uniform(100) + 1;
+    controller.persistent = NO;
+    [controller.values setValue:@(expect) forKey:@"startingLineNumber"];
+    result1 = self.view1.startingLineNumber;
+    result2 = [defaults integerForKey:@"startingLineNumber"];
+    XCTAssert(result1 == expect && result2 != expect, @"Should pass unless the random number was unlucky.");
+
+    // - setting the view updates the controller, but not defaults.
+    expect = arc4random_uniform(100) + 1;
+    self.view1.startingLineNumber = expect;
+    result1 = [[controller.values valueForKey:@"startingLineNumber"] integerValue];
+    result2 = [defaults integerForKey:@"startingLineNumber"];
+    XCTAssert(result1 == expect && result2 != expect, @"Should pass unless the random number was unlucky.");
+
+    // - setting defaults updates nothing.
+    expect = arc4random_uniform(100) + 1;
+    [defaults setInteger:expect forKey:@"startingLineNumber"];
+    result1 = self.view1.startingLineNumber;
+    result2 = [[controller.values valueForKey:@"startingLineNumber"] integerValue];
+    XCTAssert(result1 != expect && result2 != expect);
+}
+
+
+/*
+ * - test_instances_and_globals
+ *   Test to make sure that global properties are shared even when
+ *   instances gave different groupID's.
+ */
+- (void)test_instances_and_globals
+{
+    NSUInteger expect1 = arc4random_uniform(100) + 1;
+    NSUInteger expect2 = arc4random_uniform(100) + 1;
+    NSUInteger result1, result2;
+
+    MGSUserDefaultsController *controller1 = [MGSUserDefaultsController sharedControllerForGroupID:@"Group1"];
+    MGSUserDefaultsController *controller2 = [MGSUserDefaultsController sharedControllerForGroupID:@"SomeOtherGroup"];
+    MGSUserDefaultsController *controllerG = [MGSUserDefaultsController sharedController];
+
+    self.view1.startingLineNumber = expect1;
+    self.view2.startingLineNumber = expect2;
+
+    // Prove they are independent:
+    XCTAssert(self.view1.startingLineNumber == expect1 && self.view2.startingLineNumber == expect2);
+
+    // Add each instance to a different group, and then test.
+    controller1.managedInstances = [NSSet setWithArray:@[self.view1]];
+    controller2.managedInstances = [NSSet setWithArray:@[self.view2]];
+
+    // Prove they are *still* independent:
+    XCTAssert(self.view1.startingLineNumber == expect1 && self.view2.startingLineNumber == expect2);
+
+    // Let the global controller manage the startingLineNumberProperty.
+    controllerG.managedProperties = [NSSet setWithArray:@[ @"startingLineNumber" ]];
+
+    // Check that their properties are now linked.
+    expect1 = arc4random_uniform(100) + 1;
+    self.view1.startingLineNumber = expect1;
+    result1 = [[controllerG.values valueForKey:@"startingLineNumber"] integerValue];
+    result2 = self.view2.startingLineNumber;
+    XCTAssert(result1 == expect1 && result2 == expect1);
+}
+
+
+
+
+
+@end

--- a/MGSFragaria Tests/MGSUserDefaultsDefinitionsTests.m
+++ b/MGSFragaria Tests/MGSUserDefaultsDefinitionsTests.m
@@ -1,0 +1,85 @@
+//
+//  MGSUserDefaultsDefinitionsTests.m
+//  Fragaria
+//
+//  Created by Jim Derry on 3/9/15.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+#import <XCTest/XCTest.h>
+#import "MGSUserDefaultsDefinitions.h"
+#import "MGSFragariaView.h"
+#import "MGSUserDefaultsUtilities.h"
+
+
+/**
+ *  Basic tests for MGSUserDefaultsDefinitions.
+ **/
+
+@interface MGSUserDefaultsDefinitionsTests : XCTestCase
+
+@end
+
+@implementation MGSUserDefaultsDefinitionsTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+
+/*
+ *  Ensures the namingspacing inline function works correctly.
+ */
+- (void)test_namespace_function
+{
+	NSString *expects = @"MGSFragariaDefaultsUseTabStops";
+	
+	XCTAssert([expects isEqualToString:[[MGSUserDefaultsDefinitions class] fragariaNamespacedKeyForKey:MGSFragariaDefaultsUseTabStops]]);
+}
+
+
+/*
+ *  Ensures the manually-managed defaults dictionary works.
+ */
+- (void)test_fragariaDefaultsDictionaryWithNamespace
+{
+	NSLog(@"%@", [MGSUserDefaultsDefinitions fragariaDefaultsDictionaryWithNamespace]);
+	id object = [[MGSUserDefaultsDefinitions fragariaDefaultsDictionaryWithNamespace] objectForKey:@"MGSFragariaDefaultsAutoCompleteDelay"];
+	XCTAssert(object != nil);
+}
+
+
+/*
+ *  Ensures all of the properties are still available in MGSFragariaView.
+ */
+- (void)test_properties_exist
+{
+	NSDictionary *properties = [MGSUserDefaultsUtilities propertiesOfClass:[MGSFragariaView class]];
+	NSDictionary *localDict = [MGSUserDefaultsDefinitions fragariaDefaultsDictionary];
+	NSUInteger count = 0;
+	
+	for (NSString *key in [localDict allKeys])
+	{
+		
+		if (![[properties allKeys] containsObject:key] )
+		{
+			count++;
+			NSLog(@"Property `%@` not recognized.", key);
+		}
+	}
+	XCTAssert(count == 0, @"%lu of %lu properties not recgonized. Consult the log output for results.", count, localDict.count);
+}
+
+
+
+
+
+@end

--- a/MGSFragaria Tests/MGSUserDefaultsTests.m
+++ b/MGSFragaria Tests/MGSUserDefaultsTests.m
@@ -1,0 +1,129 @@
+//
+//  MGSUserDefaultsControllerTests.m
+//  Fragaria
+//
+//  Created by Jim Derry on 3/3/15.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+#import <objc/runtime.h>
+#import <XCTest/XCTest.h>
+#import "MGSFragaria.h"
+#import "MGSUserDefaults.h"
+
+
+/**
+ *  Adds some basic tests for MGSUserDefaults.
+ **/
+@interface MGSUserDefaultsTests : XCTestCase
+
+@property (nonatomic,strong) NSMutableDictionary *values;
+
+@property NSTextView *gFrag1; // todo: (jsd) fix ugly hack
+@property NSTextView *gFrag2; // todo: (jsd) fix ugly hack
+
+
+@end
+
+@implementation MGSUserDefaultsTests
+
+/*
+ * - setUp
+ */
+- (void)setUp
+{
+	[super setUp];
+}
+
+
+/*
+ * - tearDown
+ */
+- (void)tearDown
+{
+	[super tearDown];
+}
+
+
+/*
+ *  Demonstrate that we don't have to go to great lengths to ensure
+ *  that an application can only register defaults a single time.
+ */
+- (void)test_multiple_registerDefaults
+{
+	NSUserDefaults *sud = [NSUserDefaults standardUserDefaults];
+	
+	NSDictionary *dict1;
+	
+	NSString *expect1, *expect2, *result1, *result2;
+	
+	expect1 = @"Der Spiegel";
+	expect2 = @"donkey";
+ 
+	dict1 = @{ @"periodical" : expect1 };
+	[sud registerDefaults:dict1];
+	
+	dict1 = @{ @"animal" : expect2 };
+	[sud registerDefaults:dict1];
+	
+	result1 = [sud stringForKey:@"periodical"];
+	result2 = [sud stringForKey:@"animal"];
+	
+	XCTAssert(expect1 == result1 && expect2 == result2);
+}
+
+
+/*
+ *  Check that the shareduserDefaults are indeed separate instances, and are
+ *  accessible.
+ */
+- (void)test_sharedUserDefaults_groupID
+{
+	NSString *result1, *result2, *result3;
+	
+	NSString *expect1 = @"TopmostView";
+	NSString *expect2 = @"SomeOtherView";
+	NSString *expect3 = MGSUSERDEFAULTS_GLOBAL_ID;
+	
+	
+	result1 = [[MGSUserDefaults sharedUserDefaultsForGroupID:expect1] groupID];
+	result2 = [[MGSUserDefaults sharedUserDefaultsForGroupID:expect2] groupID];
+	result3 = [[MGSUserDefaults sharedUserDefaults] groupID];
+	
+	XCTAssert([result1 isEqualToString:expect1]);
+	XCTAssert([result2 isEqualToString:expect2]);
+	XCTAssert([result3 isEqualToString:expect3]);
+}
+
+
+
+/*
+ *  Make sure that MGSUserDefaults can read and write userDefaults, and delete them.
+ */
+- (void)test_sharedUserDefaults_rw
+{
+	NSString *instanceID = @"DefaultsTest";
+	NSString *key = @"MyKey";
+	NSString *value = @"SampleValue";
+	MGSUserDefaults *defaults = [MGSUserDefaults sharedUserDefaultsForGroupID:instanceID];
+	
+	[defaults setObject:value forKey:key];
+	[defaults setBool:YES forKey:@"BooleanSample"];
+	
+	// Using NSUserDefaults sees a dictionary for the instanceID.
+	NSUserDefaults *sud = [NSUserDefaults standardUserDefaults];
+	NSDictionary *results = [sud objectForKey:instanceID];
+	
+	// Using MGSUserDefaults should return the value.
+	NSString *result = [defaults objectForKey:@"MyKey"];
+	
+	NSLog(@"%@", @"Prefs .plist is at ~/Library/Preferences/xctest.plist");
+	XCTAssert(results && [result isEqualToString:value]);
+	
+	[defaults removeObjectForKey:key];
+	XCTAssert(![defaults objectForKey:key]);
+}
+
+
+@end

--- a/MGSFragaria Tests/MGSUserDefaultsUtilities.h
+++ b/MGSFragaria Tests/MGSUserDefaultsUtilities.h
@@ -1,0 +1,41 @@
+//
+//  MGSUserDefaultsUtilities.h
+//  Fragaria
+//
+//  Created by Jim Derry on 3/4/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ *  This class implements some utilities required by MGSUserDefaults tests.
+ **/
+@interface MGSUserDefaultsUtilities : NSObject
+
+/**
+ *  Returns a dictionary of all visible properties of an object, including
+ *  those from all its superclasses. Courtesy of Duncan Babbage.
+ *  @param object The object for which you want to retrieve property
+ *  information.
+ **/
++ (NSDictionary *)propertiesOfObject:(id)object;
+
+
+/**
+ *  Returns a dictionary of all visible properties of a class, including
+ *  those from all its superclasses. Courtesy of Duncan Babbage.
+ *  @param class The class for which you want to retrieve property information.
+ **/
++ (NSDictionary *)propertiesOfClass:(Class)class;
+
+
+/**
+ *  Returns a dictionary of all visible properties that are specific to
+ *  a subclass. Properties for its superclasses are not included.
+ *  Courtesy of Duncan Babbage.
+ *  @param class The class for which you want to retrieve property information.
+ **/
++ (NSDictionary *)propertiesOfSubclass:(Class)class;
+
+@end

--- a/MGSFragaria Tests/MGSUserDefaultsUtilities.m
+++ b/MGSFragaria Tests/MGSUserDefaultsUtilities.m
@@ -1,0 +1,107 @@
+//
+//  MGSUserDefaultsUtilities.m
+//  Fragaria
+//
+//  Created by Jim Derry on 3/4/15.
+//
+//
+
+#import "MGSUserDefaultsUtilities.h"
+#import <objc/objc-runtime.h>
+
+
+@implementation MGSUserDefaultsUtilities
+
+
++ (NSDictionary *) propertiesOfObject:(id)object
+{
+	Class class = [object class];
+	return [self propertiesOfClass:class];
+}
+
++ (NSDictionary *) propertiesOfClass:(Class)class
+{
+	NSMutableDictionary * properties = [NSMutableDictionary dictionary];
+	[self propertiesForHierarchyOfClass:class onDictionary:properties];
+	return [NSDictionary dictionaryWithDictionary:properties];
+}
+
++ (NSDictionary *) propertiesOfSubclass:(Class)class
+{
+	if (class == NULL) {
+		return nil;
+	}
+	
+	NSMutableDictionary *properties = [NSMutableDictionary dictionary];
+	return [self propertiesForSubclass:class onDictionary:properties];
+}
+
++ (NSMutableDictionary *)propertiesForHierarchyOfClass:(Class)class onDictionary:(NSMutableDictionary *)properties
+{
+	if (class == NULL) {
+		return nil;
+	}
+	
+	if (class == [NSObject class]) {
+		// On reaching the NSObject base class, return all properties collected.
+		return properties;
+	}
+	
+	// Collect properties from the current class.
+	[self propertiesForSubclass:class onDictionary:properties];
+	
+	// Collect properties from the superclass.
+	return [self propertiesForHierarchyOfClass:[class superclass] onDictionary:properties];
+}
+
++ (NSMutableDictionary *) propertiesForSubclass:(Class)class onDictionary:(NSMutableDictionary *)properties
+{
+	unsigned int outCount, i;
+	objc_property_t *objcProperties = class_copyPropertyList(class, &outCount);
+	for (i = 0; i < outCount; i++) {
+		objc_property_t property = objcProperties[i];
+		const char *propName = property_getName(property);
+		if(propName) {
+			const char *propType = getPropertyType(property);
+			NSString *propertyName = [NSString stringWithUTF8String:propName];
+			NSString *propertyType = [NSString stringWithUTF8String:propType];
+			[properties setObject:propertyType forKey:propertyName];
+		}
+	}
+	free(objcProperties);
+	
+	return properties;
+}
+
+static const char *getPropertyType(objc_property_t property) {
+	const char *attributes = property_getAttributes(property);
+	char buffer[1 + strlen(attributes)];
+	strcpy(buffer, attributes);
+	char *state = buffer, *attribute;
+	while ((attribute = strsep(&state, ",")) != NULL) {
+		if (attribute[0] == 'T' && attribute[1] != '@') {
+			// A C primitive type:
+			/*
+			 For example, int "i", long "l", unsigned "I", struct.
+			 Apple docs list plenty of examples of values returned. For a list
+			 of what will be returned for these primitives, search online for
+			 "Objective-c" "Property Attribute Description Examples"
+			 */
+			NSString *name = [[NSString alloc] initWithBytes:attribute + 1 length:strlen(attribute) - 1 encoding:NSASCIIStringEncoding];
+			return (const char *)[name cStringUsingEncoding:NSASCIIStringEncoding];
+		}
+		else if (attribute[0] == 'T' && attribute[1] == '@' && strlen(attribute) == 2) {
+			// An Objective C id type:
+			return "id";
+		}
+		else if (attribute[0] == 'T' && attribute[1] == '@') {
+			// Another Objective C id type:
+			NSString *name = [[NSString alloc] initWithBytes:attribute + 3 length:strlen(attribute) - 4 encoding:NSASCIIStringEncoding];
+			return (const char *)[name cStringUsingEncoding:NSASCIIStringEncoding];
+		}
+	}
+	return "";
+}
+
+
+@end

--- a/MGSUserDefaults.h
+++ b/MGSUserDefaults.h
@@ -1,0 +1,59 @@
+//
+//  MGSUserDefaults.h
+//  Fragaria
+//
+//  Created by Jim Derry on 3/3/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "MGSUserDefaultsDefinitions.h"
+
+
+/**
+ *  MGSUserDefaults is the NSUserDefaults internal replacement for use by
+ *  MGSUserDefaultsController. The main characteristic versus NSUserDefaults
+ *  is that it is assigned a `groupID` that is used to group multiple sets
+ *  of the same default together in a manner that is transparent to the
+ *  developer.
+ *
+ *  In general user defaults managed by this class are not compatible with
+ *  NSUserDefaults. It's certainly possible to use NSUserDefaults to change
+ *  or read managed keys, but there's not much point.
+ */
+@interface MGSUserDefaults : NSUserDefaults
+
+
+#pragma mark - Class Methods - Singleton Controllers
+
+/**
+ *  Provides a shared controller for `groupID`.
+ *  @param groupID Indicates the identifier for this group
+ *  of user defaults.
+ **/
++ (instancetype)sharedUserDefaultsForGroupID:(NSString *)groupID;
+
+
+/**
+ *  Provides the shared controller for global defaults.
+ **/
++ (instancetype)sharedUserDefaults;
+
+
+#pragma mark - Instance Methods
+
+/**
+ *  Registers user defaults for this instance.
+ *  @param registrationDictionary The dictionary of values to register.
+ **/
+- (void)registerDefaults:(NSDictionary *)registrationDictionary;
+
+
+#pragma mark - Properties
+
+/**
+ *  Returns the groupID of this instance of the controller.
+ **/
+@property (nonatomic,strong,readonly) NSString *groupID;
+
+@end

--- a/MGSUserDefaults.m
+++ b/MGSUserDefaults.m
@@ -1,0 +1,143 @@
+//
+//  MGSUserDefaults.m
+//  Fragaria
+//
+//  Created by Jim Derry on 3/3/15.
+//
+//
+
+#import "MGSUserDefaults.h"
+
+
+@implementation MGSUserDefaults
+
+
+#pragma mark - Class Methods - Singletons
+
+
+/*
+ *  Provides a shared controller for `groupID`.
+ *  @param groupID Indicates the identifier for this group
+ *  of user defaults.
+ */
++ (instancetype)sharedUserDefaultsForGroupID:(NSString *)groupID
+{
+	static NSMutableDictionary *instances;
+	
+	@synchronized(self) {
+
+        if (!instances)
+        {
+            instances = [[NSMutableDictionary alloc] init];
+        }
+
+		if ([[instances allKeys] containsObject:groupID])
+		{
+			return [instances objectForKey:groupID];
+		}
+		
+		MGSUserDefaults *newController = [[[self class] alloc] initWithGroupID:groupID];
+		[instances setObject:newController forKey:groupID];
+		return newController;
+	}
+}
+
+
+/*
+ *  Provides the shared controller for global defaults.
+ */
++ (instancetype)sharedUserDefaults
+{
+	return [[self class] sharedUserDefaultsForGroupID:MGSUSERDEFAULTS_GLOBAL_ID];
+}
+
+
+#pragma mark - Instance Methods
+
+/*
+ *  - registerDefaults:
+ */
+- (void)registerDefaults:(NSDictionary *)registrationDictionary
+{
+    NSDictionary *groupDict = @{ self.groupID : registrationDictionary };
+    [super registerDefaults:groupDict];
+}
+
+
+#pragma mark - Initializers
+
+
+/*
+ *  - initWithGroupID:
+ */
+- (instancetype)initWithGroupID:(NSString *)groupID
+{
+	if ((self = [super init]))
+	{
+		_groupID = groupID;
+	}
+	
+	return self;	
+}
+
+
+/*
+ *  - init
+ *    Just in case someone tries to create an instance manually,
+ *    force it to use the global defaults.
+ */
+- (instancetype)init
+{
+	return [self initWithGroupID:MGSUSERDEFAULTS_GLOBAL_ID];
+}
+
+
+#pragma mark - Other Overrides
+
+
+/*
+ *  - setObject:forKey
+ *    All of the base class set*:forKey implement this.
+ */
+- (void)setObject:(id)value forKey:(NSString *)defaultName
+{
+	NSMutableDictionary *groupDict = [NSMutableDictionary dictionaryWithDictionary:[super objectForKey:self.groupID]];
+	
+	if (!groupDict)
+	{
+		groupDict = [[NSMutableDictionary alloc] init];
+	}
+	
+	if (value)
+	{
+		[groupDict setValue:value forKey:defaultName];
+	}
+	else
+	{
+		[groupDict removeObjectForKey:defaultName];
+	}
+	
+	[super setObject:groupDict forKey:self.groupID];
+}
+
+
+/*
+ *  - objectForKey:
+ *    All of the base class *forKey: utilize this.
+ */
+- (id)objectForKey:(NSString *)defaultName
+{
+	NSDictionary *groupDict = [super objectForKey:self.groupID];
+	
+	if ([[groupDict allKeys] containsObject:defaultName])
+	{
+		return [groupDict valueForKey:defaultName];
+	}
+	
+	return nil;
+}
+
+
+#pragma mark - Private/Internal
+
+@end

--- a/MGSUserDefaultsController.h
+++ b/MGSUserDefaultsController.h
@@ -1,0 +1,100 @@
+//
+//  MGSUserDefaultsController.h
+//  Fragaria
+//
+//  Created by Jim Derry on 3/3/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "MGSUserDefaultsDefinitions.h"
+
+@class MGSFragaria;
+
+
+/**
+ *  The MGSUserDefaultsController and its related class are intended to
+ *  function as replacements for NSUserDefaults and NSUserDefaultsController,
+ *  principally adding the benefit of being able to manage multiple sets of
+ *  the same defaults keys for multiple instances of an object. This can be
+ *  particularly useful when binding to user-interface controls.
+ *
+ *  In order to support shared defaults, i.e., a default that serves as a master
+ *  for multiple instances, there's also a global default. For example if you
+ *  wish to ensure that multiple text views' `backgroundColor` is shared, you
+ *  can specifiy that that `backgroundColor` is a global property.
+ *
+ *  In general user defaults managed by this class are not compatible with
+ *  NSUserDefaults. It's certainly possible to use NSUserDefaults to change
+ *  or read managed keys, but there's not much point.
+ **/
+
+@interface MGSUserDefaultsController : NSObject
+
+
+#pragma mark - Class Methods - Singleton Controllers
+
+/**
+ *  Provides a shared controller for `groupID`.
+ *  @discuss All instances of MGSFragariaView that you wish to manage
+ *  with this toolset must belong to at least one `groupID`. Every instance
+ *  of MGSFragariaView within the same `groupID` is affected.
+ *  @param groupID Indicates the identified for this group
+ *  of user defaults.
+ **/
++ (instancetype)sharedControllerForGroupID:(NSString *)groupID;
+
+
+/**
+ *  Provides the shared controller for global defaults.
+ *  @discuss This controller manages properties that you wish to remain
+ *  common among all groups in your application. Every instance of
+ *  MGSFragariaView that belongs to a `groupID` is affected.
+ **/
++ (instancetype)sharedController;
+
+
+#pragma mark - Properties
+
+/**
+ *  The groupID uniquely identifies the preferences that
+ *  are managed by instances of this controller.
+ **/
+@property (nonatomic,strong,readonly) NSString *groupID;
+
+
+/**
+ *  Specifies the instances of MGSFragaria whose properties are
+ *  managed by an instance of this controller.
+ *
+ *  @discuss When used with the sharedController (without a groupID)
+ *  setting this property will have no effect. It will only contain
+ *  a set of MGSFragariaView instances for _all_ user defaults
+ *  controllers.
+ **/
+@property (nonatomic,strong) NSSet *managedInstances;
+
+
+/**
+ *  Specifies a set of NSString indicating the name of every property
+ *  that is to be managed by this instance of this class.
+ **/
+@property (nonatomic, strong) NSSet *managedProperties;
+
+
+/**
+ *  Indicates whether or not properties are stored in user defaults.
+ **/
+@property (nonatomic, assign, getter=isPersistent) BOOL persistent;
+
+
+/**
+ *  Provides KVO-compatible structure for use with NSObjectController.
+ *  @discuss Use only KVC setValue:forKey: and valueForKey: with this
+ *  object. In general you have no reason to manually manipulate values
+ *  with this structure. Simply set MGSFragariaView properties instead.
+ **/
+@property (nonatomic,strong, readonly) id values;
+
+
+@end

--- a/MGSUserDefaultsController.m
+++ b/MGSUserDefaultsController.m
@@ -1,0 +1,313 @@
+//
+//  MGSUserDefaultsController.m
+//  Fragaria
+//
+//  Created by Jim Derry on 3/3/15.
+//
+//
+
+#import <objc/runtime.h>
+#import "MGSUserDefaultsController.h"
+#import "MGSUserDefaultsDefinitions.h"
+#import "MGSUserDefaults.h"
+#import "MGSFragariaView.h"
+
+
+#pragma mark - NSMutableDictionary (MGSFragariaDict) - Interface
+
+/*
+ *  A category for NSMutableDictionary so that we can persist keys, if required.
+ *  Uses KVC-compliant setValue:forKey: and valueForKey: to work.
+ */
+@interface NSMutableDictionary (MGSFragariaDict)
+
+@property (nonatomic, assign) MGSUserDefaultsController *controller;
+
+@end
+
+
+#pragma mark - NSMutableDictionary (MGSFragariaDict) - Implementation
+
+
+@implementation NSMutableDictionary (MGSFragariaDict)
+
+/*
+ *  @property controller
+ */
+- (void)setController:(MGSUserDefaultsController *)controller
+{
+	objc_setAssociatedObject(self, @selector(controller), controller, OBJC_ASSOCIATION_ASSIGN);
+}
+
+- (MGSUserDefaultsController *)controller
+{
+	return objc_getAssociatedObject(self, @selector(controller));
+}
+
+
+
+/*
+ *  - setValue:forKey:
+ */
+- (void)setValue:(id)value forKey:(NSString *)key
+{
+    [self setObject:value forKey:key];
+
+    if (self.controller.persistent)
+    {
+        [[MGSUserDefaults sharedUserDefaultsForGroupID:self.controller.groupID] setObject:value forKey:key];
+    }
+}
+
+
+/*
+ *  - valueForKey:
+ */
+- (id)valueForKey:(NSString *)key
+{
+    if (self.controller.persistent)
+    {
+        return [[MGSUserDefaults sharedUserDefaultsForGroupID:self.controller.groupID] objectForKey:key];
+    }
+
+    return [self objectForKey:key];
+}
+
+@end
+
+
+
+#pragma mark - CATEGORY MGSUserDefaultsController
+
+@interface MGSUserDefaultsController ()
+
+@property (nonatomic, strong, readwrite) id values;
+
+@end
+
+
+#pragma mark - CLASS MGSUserDefaultsController - Implementation
+
+static NSMutableDictionary *controllerInstances;
+
+@implementation MGSUserDefaultsController
+
+@synthesize managedInstances = _managedInstances;
+@synthesize persistent = _persistent;
+
+
+#pragma mark - Class Methods - Singleton Controllers
+
+/*
+ *  + sharedControllerForGroupID:
+ */
++ (instancetype)sharedControllerForGroupID:(NSString *)groupID
+{
+    //static NSMutableDictionary *controllerInstances;
+	
+	@synchronized(self) {
+
+        if (!controllerInstances)
+        {
+            controllerInstances = [[NSMutableDictionary alloc] init];
+        }
+
+		if ([[controllerInstances allKeys] containsObject:groupID])
+		{
+			return [controllerInstances objectForKey:groupID];
+		}
+	
+		MGSUserDefaultsController *newController = [[[self class] alloc] initWithGroupID:groupID];
+		[controllerInstances setObject:newController forKey:groupID];
+		return newController;
+	}
+}
+
+
+/*
+ *  + sharedController
+ */
++ (instancetype)sharedController
+{
+	return [[self class] sharedControllerForGroupID:MGSUSERDEFAULTS_GLOBAL_ID];
+}
+
+
+#pragma mark - Property Accessors
+
+/*
+ *  @property managedInstances
+ */
+- (void)setManagedInstances:(NSSet *)managedInstances
+{
+	NSAssert(![self.groupID isEqualToString:MGSUSERDEFAULTS_GLOBAL_ID],
+			 @"You cannot set managedInstances for the global controller.");
+	
+	[self unregisterBindings:_managedProperties];
+    _managedInstances = managedInstances;
+	[self registerBindings:_managedProperties];
+}
+
+- (NSSet *)managedInstances
+{
+    if ([self.groupID isEqualToString:MGSUSERDEFAULTS_GLOBAL_ID])
+    {
+        NSMutableSet *allInstances = [[NSMutableSet alloc] init];
+
+        for (MGSUserDefaultsController *controllerInstance in [controllerInstances allValues])
+        {
+            if (![controllerInstance.groupID isEqualToString:MGSUSERDEFAULTS_GLOBAL_ID])
+            {
+                [allInstances unionSet:controllerInstance.managedInstances];
+            }
+        }
+        return allInstances;
+    }
+    else
+    {
+        return _managedInstances;
+    }
+}
+
+
+/*
+ *  @property managedProperties
+ */
+- (void)setManagedProperties:(NSSet *)managedProperties
+{
+	[self unregisterBindings:_managedProperties];
+    _managedProperties = managedProperties;
+	[self registerBindings:_managedProperties];
+}
+
+
+/*
+ *  @property persistent
+ */
+- (void)setPersistent:(BOOL)persistent
+{
+	if (_persistent == persistent) return;
+
+    _persistent = persistent;
+
+	if (persistent)
+	{
+        [[NSUserDefaults standardUserDefaults] setObject:self.values forKey:self.groupID];
+        
+		[[NSUserDefaultsController sharedUserDefaultsController] addObserver:self
+																  forKeyPath:[NSString stringWithFormat:@"values.%@", self.groupID]
+																	 options:NSKeyValueObservingOptionNew
+																	 context:(__bridge void *)(self.groupID)];
+	}
+	else
+	{
+		[[NSUserDefaultsController sharedUserDefaultsController] removeObserver:self
+                                                                     forKeyPath:[NSString stringWithFormat:@"values.%@", self.groupID]
+                                                                        context:(__bridge void *)(self.groupID)];
+
+        NSDictionary *defaultsValues = [[NSUserDefaults standardUserDefaults] objectForKey:self.groupID];
+
+        for (NSString *key in self.values)
+        {
+            if (![[self.values valueForKey:key] isEqualTo:[defaultsValues valueForKey:key]])
+            {
+                [self.values setValue:[defaultsValues valueForKey:key] forKey:key];
+            }
+        }
+	}
+}
+
+- (BOOL)isPersistent
+{
+	return _persistent;
+}
+
+
+#pragma mark - Initializers (not exposed)
+
+/*
+ *  - initWithGroupID:
+ */
+- (instancetype)initWithGroupID:(NSString *)groupID
+{
+	if ((self = [super init]))
+	{
+		_groupID = groupID;
+
+		NSDictionary *defaults = [[MGSUserDefaultsDefinitions class] fragariaDefaultsDictionary];
+		
+		[[MGSUserDefaults sharedUserDefaultsForGroupID:groupID] registerDefaults:defaults];
+		_values = [[NSMutableDictionary alloc] initWithDictionary:defaults];
+		[(NSMutableDictionary *)_values setController:self];
+	}
+	
+	return self;
+}
+
+
+/*
+ *  - init
+ *    Just in case someone tries to create their own instance
+ *    of this class, we'll make sure it's always "Global".
+ */
+- (instancetype)init
+{
+	return [self initWithGroupID:MGSUSERDEFAULTS_GLOBAL_ID];
+}
+
+
+#pragma mark - Binding Registration/Unregistration and KVO Handling
+
+
+/*
+ *  -registerBindings
+ */
+- (void)registerBindings:(NSSet *)propertySet
+{
+	// Bind all relevant properties of each instance to `values` dictionary.
+	[propertySet enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id key, BOOL *stop) {
+		for (MGSFragariaView *fragaria in self.managedInstances)
+		{
+			[fragaria bind:key toObject:self.values withKeyPath:key options:nil];
+		}
+	}];
+}
+
+
+/*
+ *  - unregisterBindings:
+ */
+- (void)unregisterBindings:(NSSet *)propertySet
+{
+    // Stop observing properties
+    [propertySet enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id key, BOOL *stop) {
+        for (MGSFragariaView *fragaria in self.managedInstances)
+        {
+            [fragaria unbind:key];
+        }
+    }];
+}
+
+
+/*
+ * - observeValueForKeyPath:ofObject:change:context:
+ */
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+	// The only keypath we've registered, but let's check in case we accidentally something.
+	if ([[NSString stringWithFormat:@"values.%@", self.groupID] isEqualToString:keyPath])
+	{
+        NSDictionary *defaultsValues = [[NSUserDefaults standardUserDefaults] objectForKey:self.groupID];
+        for (NSString *key in defaultsValues)
+        {
+            // If we use self.value valueForKey: here, we will get the value from defaults.
+            if (![[defaultsValues valueForKey:key] isEqualTo:[self.values objectForKey:key]])
+            {
+                [self.values setValue:[defaultsValues valueForKey:key] forKey:key];
+            }
+        }
+	}
+}
+
+
+@end

--- a/MGSUserDefaultsDefinitions.h
+++ b/MGSUserDefaultsDefinitions.h
@@ -1,0 +1,202 @@
+//
+//  MGSUserDefaultsDefinitions.h
+//  Fragaria
+//
+//  Created by Jim Derry on 3/3/15.
+//
+//
+
+
+#pragma mark - Property User Defaults Keys
+/**
+ *  #Fragaria Property User Defaults Keys
+ *
+ *  ## Use with MGSUserDefaultsController and MGSUserDefaults:
+ *  These keys can be used in your code to manage Fragaria properties and
+ *  user defaults for any instance of MGSFragariaView. The keys' names
+ *  correspond fairly well with MGSFragriaView's properties properties.
+ *
+ *  ## For use in KVO/KVC/IB:
+ *  The string values can be found in MGSUserDefaults.m and is also documented
+ *  in the comments after each declaration below. For convenience the string
+ *  value is identical to the MGSFaragariaView property name. These definitions
+ *  are also critical to how MGSUserDefaultsController operates, so do not
+ *  change them for namespacing purposes (see +fragariaNamespacedKeyForKey).
+ *
+ *  ## For use when managing defaults and properties yourself:
+ *  For convenience and type safety some convenience methods are provided in
+ *  this class in order to use the constants as much as possible.
+ */
+
+// Configuring Syntax Highlighting
+extern NSString * const MGSFragariaDefaultsSyntaxColoured;                        // BOOL       syntaxColoured
+extern NSString * const MGSFragariaDefaultsSyntaxDefinitionName;                  // NSString   syntaxDefinitionName
+extern NSString * const MGSFragariaDefaultsColoursMultiLineStrings;               // BOOL       coloursMultiLineStrings
+extern NSString * const MGSFragariaDefaultsColoursOnlyUntilEndOfLine;             // BOOL       coloursOnlyUntilEndOfLine
+
+// Configuring Autocompletion
+extern NSString * const MGSFragariaDefaultsAutoCompleteDelay;                     // double     autoCompleteDelay
+extern NSString * const MGSFragariaDefaultsAutoCompleteEnabled;                   // BOOL       autoCompleteEnabled
+extern NSString * const MGSFragariaDefaultsAutoCompleteWithKeywords;              // BOOL       autoCompleteWithKeywords
+
+// Highlighting the current line
+extern NSString * const MGSFragariaDefaultsCurrentLineHighlightColour;            // NSColor    currentLineHighlightColour
+extern NSString * const MGSFragariaDefaultsHighlightsCurrentLine;                 // BOOL       highlightsCurrentLine
+
+// Configuring the Gutter
+extern NSString * const MGSFragariaDefaultsShowsGutter;                           // BOOL       showsGutter
+extern NSString * const MGSFragariaDefaultsMinimumGutterWidth;                    // CGFloat    minimumGutterWidth
+extern NSString * const MGSFragariaDefaultsShowsLineNumbers;                      // BOOL       showsLineNumbers
+extern NSString * const MGSFragariaDefaultsStartingLineNumber;                    // NSUInteger startingLineNumber
+extern NSString * const MGSFragariaDefaultsGutterFont;                            // NSFont     gutterFont
+extern NSString * const MGSFragariaDefaultsGutterTextColour;                      // NSColor    gutterTextColour
+
+// Showing Syntax Errors
+extern NSString * const MGSFragariaDefaultsShowsSyntaxErrors;                     // BOOL       showsSyntaxErrors
+
+// Tabulation and Indentation
+extern NSString * const MGSFragariaDefaultsTabWidth;                              // NSInteger  tabWidth
+extern NSString * const MGSFragariaDefaultsIndentWidth;                           // NSUInteger indentWidth
+extern NSString * const MGSFragariaDefaultsUseTabStops;                           // BOOL       useTabStops
+extern NSString * const MGSFragariaDefaultsIndentWithSpaces;                      // BOOL       indentWithSpaces
+extern NSString * const MGSFragariaDefaultsIndentBracesAutomatically;             // BOOL       indentBracesAutomatically
+extern NSString * const MGSFragariaDefaultsIndentNewLinesAutomatically;           // BOOL       indentNewLinesAutomatically
+
+// Automatic Bracing
+extern NSString * const MGSFragariaDefaultsInsertClosingBraceAutomatically;       // BOOL   insertClosingBraceAutomatically
+extern NSString * const MGSFragariaDefaultsInsertClosingParenthesisAutomatically; // BOOL   insertClosingParenthesisAutomatically
+extern NSString * const MGSFragariaDefaultsShowsMatchingBraces;                   // BOOL   showsMatchingBraces
+
+// Page Guide and Line Wrap
+extern NSString * const MGSFragariaDefaultsPageGuideColumn;                       // NSInteger  pageGuideColumn
+extern NSString * const MGSFragariaDefaultsShowsPageGuide;                        // BOOL       showsPageGuide
+extern NSString * const MGSFragariaDefaultsLineWrap;                              // BOOL       lineWrap
+
+// Showing Invisible Characters
+extern NSString * const MGSFragariaDefaultsShowsInvisibleCharacters;              // BOOL    showsInvisibleCharacters
+extern NSString * const MGSFragariaDefaultsTextInvisibleCharactersColour;         // NSColor textInvisibleCharactersColour
+
+// Configuring Text Appearance
+extern NSString * const MGSFragariaDefaultsTextColor;                             // NSColor textColor
+extern NSString * const MGSFragariaDefaultsBackgroundColor;                       // NSColor backgroundColor
+extern NSString * const MGSFragariaDefaultsTextFont;                              // NSFont  textFont
+
+// Configuring Additional Text View Behavior
+extern NSString * const MGSFragariaDefaultsHasVerticalScroller;                   // BOOL    hasVerticalScroller
+extern NSString * const MGSFragariaDefaultsInsertionPointColor;                   // NSColor insertionPointColor
+extern NSString * const MGSFragariaDefaultsScrollElasticityDisabled;              // BOOL    scrollElasticityDisabled
+
+// Syntax Highlighting Colours
+extern NSString * const MGSFragariaDefaultsColourForAutocomplete;                 // NSColor colourForAutocomplete
+extern NSString * const MGSFragariaDefaultsColourForAttributes;                   // NSColor colourForAttributes
+extern NSString * const MGSFragariaDefaultsColourForCommands;                     // NSColor colourForCommands
+extern NSString * const MGSFragariaDefaultsColourForComments;                     // NSColor colourForComments
+extern NSString * const MGSFragariaDefaultsColourForInstructions;                 // NSColor colourForInstructions
+extern NSString * const MGSFragariaDefaultsColourForKeywords;                     // NSColor colourForKeywords
+extern NSString * const MGSFragariaDefaultsColourForNumbers;                      // NSColor colourForNumbers
+extern NSString * const MGSFragariaDefaultsColourForStrings;                      // NSColor colourForStrings
+extern NSString * const MGSFragariaDefaultsColourForVariables;                    // NSColor colourForVariables
+
+// Syntax Highlighter Colouring Options
+extern NSString * const MGSFragariaDefaultsColoursAttributes;                     // BOOL coloursAttributes
+extern NSString * const MGSFragariaDefaultsColoursAutocomplete;                   // BOOL coloursAutocomplete
+extern NSString * const MGSFragariaDefaultsColoursCommands;                       // BOOL coloursCommands
+extern NSString * const MGSFragariaDefaultsColoursComments;                       // BOOL coloursComments
+extern NSString * const MGSFragariaDefaultsColoursInstructions;                   // BOOL coloursInstructions
+extern NSString * const MGSFragariaDefaultsColoursKeywords;                       // BOOL coloursKeywords
+extern NSString * const MGSFragariaDefaultsColoursNumbers;                        // BOOL coloursNumbers
+extern NSString * const MGSFragariaDefaultsColoursStrings;                        // BOOL coloursStrings
+extern NSString * const MGSFragariaDefaultsColoursVariables;                      // BOOL coloursVariables
+
+
+
+/**
+ *  This macro defines the identifier for the global defaults, and is the name
+ *  that will be used for the global defaults dictionary written to defaults.
+ *  You should never have to worry about this, and is only used if you are
+ *  using MGSUserDefaultsController.
+ **/
+#define MGSUSERDEFAULTS_GLOBAL_ID @"Global"
+
+
+@class MGSFragariaView;
+
+
+/**
+ *  MGSUserDefaultsDefinitions class consists of several class methods that
+ *  serve as conveniences for working with MGSFragaria. Although it is used
+ *  by MGSUserDefaultsController, it may be of value to you if you choose to
+ *  manage your own defaults and properties, as it can provide useful defaults
+ *  for instances of Fragaria.
+ **/
+@interface MGSUserDefaultsDefinitions : NSObject
+
+
+#pragma mark - Class Methods - Defaults Dictionaries
+
+
+/**
+ *  This class method returns an NSDictionary with key-value pairs offering
+ *  suitable defaults that you can use in your application with
+ *  `registerDefaults`, if you are managing your own defaults and properties.
+ *
+ *  @discuss If you are using MGSUserDefaultsController, then you should have
+ *  no need to registerDefaults with these; it will be handled automatically.
+ **/
++ (NSDictionary *)fragariaDefaultsDictionary;
+
+
+/**
+ *  This class method returns an dictionary that will be added automatically
+ *  to +fragariaDefaultsDictionary and +fragariaDefaultsDictionaryWithNamespace.
+ *
+ *  @discuss The default implementation returns an empty dictionary. This method
+ *  should be implemented by subclasses to return a dictionary of your preferred
+ *  defaults settings so that you can override defaults choices that are already
+ *  made. In this way you can avoid both altering the original source code of 
+ *  this class and rewriting it entirely.
+ **/
++ (NSDictionary *)fragariaSupplementalDefaultsDictionary;
+
+
+#pragma mark - Class Methods - Manual Management Support
+
+
+/**
+ *  This method will namespace the string values of the constant string above,
+ *  and is intended for use if you are managing your own properties and
+ *  defaults.
+ *
+ *  @discuss Because the string values are simply the property name, you may
+ *  not want to use them as NSUserDefaults keys without applying a namespace to
+ *  them, lest you collide with other keys in your application.
+ *
+ *  @param aString The key to namespace.
+ **/
++ (NSString *)fragariaNamespacedKeyForKey:(NSString *)aString;
+
+
+/**
+ *  This method will return the `fragariaDefaultsDictionary` as above, but with
+ *  each key namespaced via `fragariaNamespacedKeyForKey:`. It is intended for
+ *  use if you are managing your own properties and defaults.
+ *
+ *  @discuss Just in case you're adamant about managing Fragaria properties and
+ *  user defaults yourself, you can use this class method instead of 
+ *  `fragariaDefaultsDictionary`.
+ **/
++ (NSDictionary *)fragariaDefaultsDictionaryWithNamespace;
+
+
+/**
+ *  This method will apply the defaults to an instance of MGSFragaria. It is
+ *  meant only as a convenience to set your instance' defaults one time only,
+ *  and only if you are managing your own properties and user defaults. After
+ *  this, you're on your own.
+ *
+ *  @param fragaria In instance of Fragaria in which to apply defaults.
+ **/
++ (void)applyDefaultsToFragariaView:(MGSFragariaView *)fragaria;
+
+
+@end

--- a/MGSUserDefaultsDefinitions.m
+++ b/MGSUserDefaultsDefinitions.m
@@ -1,0 +1,241 @@
+//
+//  MGSUserDefaultsDefinitions.m
+//  Fragaria
+//
+//  Created by Jim Derry on 3/3/15.
+//
+//
+
+
+#pragma mark - Property User Defaults Keys
+
+// Configuring Syntax Highlighting
+NSString * const MGSFragariaDefaultsIsSyntaxColoured =          @"syntaxColoured";
+NSString * const MGSFragariaDefaultsSyntaxDefinitionName =      @"syntaxDefinitionName";
+NSString * const MGSFragariaDefaultsColoursMultiLineStrings =   @"coloursMultiLineStrings";
+NSString * const MGSFragariaDefaultsColoursOnlyUntilEndOfLine = @"coloursOnlyUntilEndOfLine";
+
+// Configuring Autocompletion
+NSString * const MGSFragariaDefaultsAutoCompleteDelay =        @"autoCompleteDelay";
+NSString * const MGSFragariaDefaultsAutoCompleteEnabled =      @"autoCompleteEnabled";
+NSString * const MGSFragariaDefaultsAutoCompleteWithKeywords = @"autoCompleteWithKeywords";
+
+// Highlighting the current line
+NSString * const MGSFragariaDefaultsCurrentLineHighlightColour = @"currentLineHighlightColour";
+NSString * const MGSFragariaDefaultsHighlightsCurrentLine =      @"highlightsCurrentLine";
+
+// Configuring the Gutter
+NSString * const MGSFragariaDefaultsShowsGutter =        @"showsGutter";
+NSString * const MGSFragariaDefaultsMinimumGutterWidth = @"minimumGutterWidth";
+NSString * const MGSFragariaDefaultsShowsLineNumbers =   @"showsLineNumbers";
+NSString * const MGSFragariaDefaultsStartingLineNumber = @"startingLineNumber";
+NSString * const MGSFragariaDefaultsGutterFont =         @"gutterFont";
+NSString * const MGSFragariaDefaultsGutterTextColour =   @"gutterTextColour";
+
+// Showing Syntax Errors
+NSString * const MGSFragariaDefaultsShowsSyntaxErrors = @"showsSyntaxErrors";
+
+// Tabulation and Indentation
+NSString * const MGSFragariaDefaultsTabWidth =                    @"tabWidth";
+NSString * const MGSFragariaDefaultsIndentWidth =                 @"indentWidth";
+NSString * const MGSFragariaDefaultsIndentWithSpaces =            @"indentWithSpaces";
+NSString * const MGSFragariaDefaultsUseTabStops =                 @"useTabStops";
+NSString * const MGSFragariaDefaultsIndentBracesAutomatically =   @"indentBracesAutomatically";
+NSString * const MGSFragariaDefaultsIndentNewLinesAutomatically = @"indentNewLinesAutomatically";
+
+// Automatic Bracing
+NSString * const MGSFragariaDefaultsInsertClosingBraceAutomatically =       @"insertClosingBraceAutomatically";
+NSString * const MGSFragariaDefaultsInsertClosingParenthesisAutomatically = @"insertClosingParenthesisAutomatically";
+NSString * const MGSFragariaDefaultsShowsMatchingBraces =                   @"showsMatchingBraces";
+
+// Page Guide and Line Wrap
+NSString * const MGSFragariaDefaultsPageGuideColumn = @"pageGuideColumn";
+NSString * const MGSFragariaDefaultsShowsPageGuide =  @"showsPageGuide";
+NSString * const MGSFragariaDefaultsLineWrap =        @"lineWrap";
+
+// Showing Invisible Characters
+NSString * const MGSFragariaDefaultsShowsInvisibleCharacters =      @"showsInvisibleCharacters";
+NSString * const MGSFragariaDefaultsTextInvisibleCharactersColour = @"textInvisibleCharactersColour";
+
+// Configuring Text Appearance
+NSString * const MGSFragariaDefaultsTextColor =       @"textColor";
+NSString * const MGSFragariaDefaultsBackgroundColor = @"backgroundColor";
+NSString * const MGSFragariaDefaultsTextFont =        @"textFont";
+
+// Configuring Additional Text View Behavior
+NSString * const MGSFragariaDefaultsHasVerticalScroller =      @"hasVerticalScroller";
+NSString * const MGSFragariaDefaultsInsertionPointColor =      @"insertionPointColor";
+NSString * const MGSFragariaDefaultsScrollElasticityDisabled = @"scrollElasticityDisabled";
+
+// Syntax Highlighting Colours
+NSString * const MGSFragariaDefaultsColourForAutocomplete = @"colourForAutocomplete";
+NSString * const MGSFragariaDefaultsColourForAttributes =   @"colourForAttributes";
+NSString * const MGSFragariaDefaultsColourForCommands =     @"colourForCommands";
+NSString * const MGSFragariaDefaultsColourForComments =     @"colourForComments";
+NSString * const MGSFragariaDefaultsColourForInstructions = @"colourForInstructions";
+NSString * const MGSFragariaDefaultsColourForKeywords =     @"colourForKeywords";
+NSString * const MGSFragariaDefaultsColourForNumbers =      @"colourForNumbers";
+NSString * const MGSFragariaDefaultsColourForStrings =      @"colourForStrings";
+NSString * const MGSFragariaDefaultsColourForVariables =    @"colourForVariables";
+
+// Syntax Highlighter Colouring Options
+NSString * const MGSFragariaDefaultsColoursAttributes =   @"coloursAttributes";
+NSString * const MGSFragariaDefaultsColoursAutocomplete = @"coloursAutocomplete";
+NSString * const MGSFragariaDefaultsColoursCommands =     @"coloursCommands";
+NSString * const MGSFragariaDefaultsColoursComments =     @"coloursComments";
+NSString * const MGSFragariaDefaultsColoursInstructions = @"coloursInstructions";
+NSString * const MGSFragariaDefaultsColoursKeywords =     @"coloursKeywords";
+NSString * const MGSFragariaDefaultsColoursNumbers =      @"coloursNumbers";
+NSString * const MGSFragariaDefaultsColoursStrings =      @"coloursStrings";
+NSString * const MGSFragariaDefaultsColoursVariables =    @"coloursVariables";
+
+
+
+#import <MGSFragaria/MGSFragariaView.h>
+#import "MGSUserDefaultsDefinitions.h"
+#import "MGSSyntaxController.h"
+
+#pragma mark - Implementation
+
+@implementation MGSUserDefaultsDefinitions
+
+
+#pragma mark - Defaults Dictionaries
+
+#define ARCHIVED_COLOR(rd, gr, bl) [NSArchiver archivedDataWithRootObject:\
+[NSColor colorWithCalibratedRed:rd green:gr blue:bl alpha:1.0f]]
+#define ARCHIVED_OBJECT(obj) [NSArchiver archivedDataWithRootObject:obj]
+
+/*
+ *  + fragariaDefaultsDictionary
+ */
++ (NSDictionary *)fragariaDefaultsDictionary
+{
+	__block NSMutableDictionary *dictionary;
+	
+	dictionary = [NSMutableDictionary dictionaryWithDictionary:@{
+		 MGSFragariaDefaultsIsSyntaxColoured : @YES,
+		 MGSFragariaDefaultsSyntaxDefinitionName : [[MGSSyntaxController class] standardSyntaxDefinitionName],
+		 MGSFragariaDefaultsColoursMultiLineStrings : @NO,
+		 MGSFragariaDefaultsColoursOnlyUntilEndOfLine : @YES,
+
+ 		 MGSFragariaDefaultsAutoCompleteDelay : @1.0f,
+		 MGSFragariaDefaultsAutoCompleteEnabled : @NO,
+		 MGSFragariaDefaultsAutoCompleteWithKeywords : @YES,
+
+		 MGSFragariaDefaultsCurrentLineHighlightColour : ARCHIVED_COLOR(0.96f,0.96f,0.71f),
+		 MGSFragariaDefaultsHighlightsCurrentLine : @NO,
+
+		 MGSFragariaDefaultsShowsGutter : @YES,
+		 MGSFragariaDefaultsMinimumGutterWidth : @40,
+		 MGSFragariaDefaultsShowsLineNumbers : @YES,
+		 MGSFragariaDefaultsStartingLineNumber : @1,
+		 MGSFragariaDefaultsGutterFont : ARCHIVED_OBJECT([NSFont fontWithName:@"Menlo" size:11]),
+		 MGSFragariaDefaultsGutterTextColour : ARCHIVED_OBJECT([NSColor colorWithCalibratedWhite:0.42f alpha:1.0f]),
+
+		 MGSFragariaDefaultsShowsSyntaxErrors : @YES,
+
+		 MGSFragariaDefaultsTabWidth : @4,
+		 MGSFragariaDefaultsIndentWidth : @4,
+		 MGSFragariaDefaultsUseTabStops : @YES,
+		 MGSFragariaDefaultsIndentWithSpaces : @NO,
+		 MGSFragariaDefaultsIndentBracesAutomatically : @YES,
+		 MGSFragariaDefaultsIndentNewLinesAutomatically : @YES,
+
+		 
+		 MGSFragariaDefaultsInsertClosingBraceAutomatically : @NO,
+		 MGSFragariaDefaultsInsertClosingParenthesisAutomatically : @NO,
+		 MGSFragariaDefaultsShowsMatchingBraces : @YES,
+		 
+		 MGSFragariaDefaultsPageGuideColumn : @80,
+		 MGSFragariaDefaultsShowsPageGuide : @NO,
+		 MGSFragariaDefaultsLineWrap : @YES,
+
+		 MGSFragariaDefaultsShowsInvisibleCharacters : @NO,
+		 MGSFragariaDefaultsTextInvisibleCharactersColour : ARCHIVED_OBJECT([NSColor controlTextColor]),
+
+		 MGSFragariaDefaultsTextColor : ARCHIVED_OBJECT([NSColor textColor]),
+		 MGSFragariaDefaultsBackgroundColor : ARCHIVED_OBJECT([NSColor whiteColor]),
+		 MGSFragariaDefaultsTextFont : ARCHIVED_OBJECT([NSFont fontWithName:@"Menlo" size:11]),
+
+		 MGSFragariaDefaultsHasVerticalScroller : @YES,
+		 MGSFragariaDefaultsInsertionPointColor : ARCHIVED_OBJECT([NSColor textColor]),
+		 MGSFragariaDefaultsScrollElasticityDisabled : @NO,
+	
+		 MGSFragariaDefaultsColourForAutocomplete : ARCHIVED_COLOR(0.84f,0.41f,0.006f),
+		 MGSFragariaDefaultsColourForAttributes : ARCHIVED_COLOR(0.50f,0.5f,0.2f),
+		 MGSFragariaDefaultsColourForCommands : ARCHIVED_COLOR(0.031f,0.0f,0.855f),
+		 MGSFragariaDefaultsColourForComments : ARCHIVED_COLOR(0.0f,0.45f,0.0f),
+		 MGSFragariaDefaultsColourForInstructions : ARCHIVED_COLOR(0.45f,0.45f,0.45f),
+		 MGSFragariaDefaultsColourForKeywords : ARCHIVED_COLOR(0.737f,0.0f,0.647f),
+		 MGSFragariaDefaultsColourForNumbers : ARCHIVED_COLOR(0.031f,0.0f,0.855f),
+		 MGSFragariaDefaultsColourForStrings : ARCHIVED_COLOR(0.804f,0.071f,0.153f),
+		 MGSFragariaDefaultsColourForVariables : ARCHIVED_COLOR(0.73f,0.0f,0.74f),
+		 
+		 MGSFragariaDefaultsColoursAttributes : @YES,
+		 MGSFragariaDefaultsColoursAutocomplete : @NO,
+		 MGSFragariaDefaultsColoursCommands : @YES,
+		 MGSFragariaDefaultsColoursComments : @YES,
+		 MGSFragariaDefaultsColoursInstructions : @YES,
+		 MGSFragariaDefaultsColoursKeywords : @YES,
+		 MGSFragariaDefaultsColoursNumbers : @YES,
+		 MGSFragariaDefaultsColoursStrings : @YES,
+		 MGSFragariaDefaultsColoursVariables : @YES,
+	 }];
+	
+	[[[self class] fragariaSupplementalDefaultsDictionary] enumerateKeysAndObjectsUsingBlock:^(id key, id object, BOOL *stop) {
+		[dictionary setObject:object forKey:key];
+	}];
+	
+	return dictionary;
+}
+
+
+/*
+ *  + fragariaSupplementalDefaultsDictionary
+ */
++ (NSDictionary *)fragariaSupplementalDefaultsDictionary
+{
+	return @{ };
+}
+
+
+#pragma mark - Manual Management Support
+
+/*
+ *  + fragariaNamespacedKeyForKey:
+ */
++ (NSString *)fragariaNamespacedKeyForKey:(NSString *)aString
+{
+	NSString *character = [[aString substringToIndex:1] uppercaseString];
+	NSMutableString *changedString = [NSMutableString stringWithString:aString];
+	[changedString replaceCharactersInRange:NSMakeRange(0, 1) withString:character];
+	return [NSString stringWithFormat:@"MGSFragariaDefaults%@", changedString];
+}
+
+
+/*
+ *  + fragariaDefaultsDictionaryWithNamespace
+ */
++ (NSDictionary *)fragariaDefaultsDictionaryWithNamespace
+{
+	__block NSMutableDictionary *dictionary = [[NSMutableDictionary alloc] init];
+	[[[self class] fragariaDefaultsDictionary] enumerateKeysAndObjectsUsingBlock:^(id key, id object, BOOL *stop) {
+		dictionary[[[self class] fragariaNamespacedKeyForKey:key]] = object;
+	}];
+	return dictionary;
+}
+
+
+/*
+ *  + applyDefaultsToFragariaView
+ */
++ (void)applyDefaultsToFragariaView:(MGSFragariaView *)fragaria
+{
+	for (NSString *key in [[self class] fragariaDefaultsDictionary])
+	{
+		[fragaria setValue:[[self class] fragariaDefaultsDictionary][key] forKey:key];
+	}
+}
+
+@end


### PR DESCRIPTION
I thought I would get this in to simplify all of XCode project file merge conflicts every time I pull Master.

This coordinator suite manages desired properties between one or more instances of MGSFragariaView, optionally persisting the desired properties' values in the user defaults system.
- "groups" are defined and one or more MGSFragariaView instances are added to a group.
- Desired MGSFragariaView properties are assigned to a group. All MGSFragariaView instances will then keep these properties in sync.
- These properties can option be persisted to user defaults.
- \+ [MGSUserDefaultsDefinitions allValues] could be used to coordinate _all_ properties if this is wanted.

The behavior above allows multiple MGSFragariaView instances to have separate property values for some things, and common property values for another. For example an NSDocument based application may have a common background color for all instances (controlled by the new coordinator), but allow word-wrap independently. Each NSDocument's MGSFragariaView would belong to the same groupID. Managed properties would automatically persist to user defaults if desired.

Additionally there is a "Master" group, wherein desired properties can be shared amongst _all_ MGSFragariaView instances, regardless of the group that the instance belongs to. It works exactly as above, except the "group" consists of every member of all groups.

This behavior satisfies a case in which multiple groupID's must be used, but where some master property coordination is also desired. For example an single window based application may have two MGSFragariaView instances. Each instance belongs to a _separate_ groupID so that their properties' values can remain independent and persist to user defaults. However the Master is still capable of ensuring, for example, that some elements remain common (e.g., background color).

I hope this explanation is not too convoluted, as the concept is simple. In most use cases the "Master" can be forgotten, I would think.

The units tests are pretty comprehensive; if you step through them you can have a very good idea of what this accomplishes.

---

Next will be re-implementing the preferences panes to work transparently with this. Obviously they won't necessarily be "preference" panes anymore, but general appearance control views, although they will certainly still be able to be used for Preferences.
