### PR TITLE
Individual errors

### DIFF
--- a/Applications/MGSFragariaView/Features.xib
+++ b/Applications/MGSFragariaView/Features.xib
@@ -16,246 +16,12 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="272" y="176" width="450" height="487"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1600" height="877"/>
             <view key="contentView" id="1Bg-1l-liR">
                 <rect key="frame" x="0.0" y="0.0" width="450" height="487"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <box autoresizesSubviews="NO" title="Upper View" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="UbJ-ck-GAa">
-                        <rect key="frame" x="17" y="243" width="416" height="224"/>
-                        <view key="contentView">
-                            <rect key="frame" x="1" y="1" width="414" height="208"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            <subviews>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="h9x-vk-QWV">
-                                    <rect key="frame" x="16" y="182" width="142" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Syntax Highlighting" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="CeR-vU-MuM">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.syntaxColoured" id="sd1-5m-Oey">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xQu-2v-Pd1">
-                                    <rect key="frame" x="16" y="162" width="108" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Line Numbers" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="E9f-CF-YSK">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsLineNumbers" id="S4X-7c-agd">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nJt-D9-00Z">
-                                    <rect key="frame" x="16" y="142" width="133" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Show Page Guide" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="G9A-sZ-iEl">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsPageGuide" id="S1v-Mv-O5V">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RdX-7u-GMl">
-                                    <rect key="frame" x="16" y="102" width="176" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Line Wrap at Page Guide" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="iUY-em-XBp">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="enabled" keyPath="self.viewTop.lineWrap" id="yEg-b0-iqm"/>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.lineWrapsAtPageGuide" id="GMR-8K-OsD">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YXZ-Zp-BPs">
-                                    <rect key="frame" x="16" y="82" width="90" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Error Icons" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="VCG-Ry-o24">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsSyntaxErrors" id="SqS-Gd-u55">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
-                                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QYV-Lc-Kqa">
-                                    <rect key="frame" x="343" y="180" width="53" height="22"/>
-                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="iaS-d8-Frq">
-                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="ajB-Qz-3wQ"/>
-                                        <font key="font" metaFont="system"/>
-                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    </textFieldCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.startingLineNumber" id="AQb-eP-OPX">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEditable" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </textField>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uA5-hi-sae">
-                                    <rect key="frame" x="197" y="183" width="140" height="17"/>
-                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Starting Line Number:" id="oi7-W4-VwP">
-                                        <font key="font" metaFont="system"/>
-                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                    </textFieldCell>
-                                </textField>
-                                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TBN-LA-BIG">
-                                    <rect key="frame" x="343" y="152" width="53" height="22"/>
-                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="DZK-LF-T8T">
-                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="lvY-cd-zaM"/>
-                                        <font key="font" metaFont="system"/>
-                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    </textFieldCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.minimumGutterWidth" id="xVR-aM-C4m">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEditable" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </textField>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhc-PU-R1S">
-                                    <rect key="frame" x="16" y="63" width="61" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Gutter" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="L8e-dj-LCp">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsGutter" id="jx8-D0-dao">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gg8-RP-10h">
-                                    <rect key="frame" x="16" y="43" width="118" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Vertical Scroller" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KYC-47-lpS">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.hasVerticalScroller" id="h7l-Iy-i2F">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LvK-DR-ay9">
-                                    <rect key="frame" x="16" y="23" width="174" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Scroll Elasticity Disabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="F7I-jJ-R7q">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.scrollElasticityDisabled" id="XI9-Om-oB5">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="znJ-t0-gXd">
-                                    <rect key="frame" x="220" y="155" width="117" height="17"/>
-                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Min. Gutter Width:" id="l6v-Gm-elJ">
-                                        <font key="font" metaFont="system"/>
-                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                    </textFieldCell>
-                                </textField>
-                                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DP3-Bn-fUI">
-                                    <rect key="frame" x="343" y="123" width="53" height="22"/>
-                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="vca-Qa-xFM">
-                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="SWt-OP-Pn7"/>
-                                        <font key="font" metaFont="system"/>
-                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    </textFieldCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.pageGuideColumn" id="4CC-Rh-U7f">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEditable" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </textField>
-                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hxH-Dy-Yvj">
-                                    <rect key="frame" x="202" y="126" width="135" height="17"/>
-                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Page Guide Column:" id="BDb-al-XjL">
-                                        <font key="font" metaFont="system"/>
-                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                    </textFieldCell>
-                                </textField>
-                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DDQ-O1-djJ">
-                                    <rect key="frame" x="16" y="122" width="85" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Line Wrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Yyj-Ay-JJt">
-                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                        <font key="font" metaFont="system"/>
-                                    </buttonCell>
-                                    <connections>
-                                        <binding destination="-2" name="value" keyPath="self.viewTop.lineWrap" id="UHM-cE-gJy">
-                                            <dictionary key="options">
-                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
-                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
-                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
-                                            </dictionary>
-                                        </binding>
-                                    </connections>
-                                </button>
-                            </subviews>
-                        </view>
-                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                        <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    </box>
-                    <box autoresizesSubviews="NO" title="Lower View" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="OMj-yp-1Jo">
+                    <box autoresizesSubviews="NO" misplaced="YES" title="Lower View" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="OMj-yp-1Jo">
                         <rect key="frame" x="17" y="16" width="416" height="225"/>
                         <view key="contentView">
                             <rect key="frame" x="1" y="1" width="414" height="209"/>
@@ -295,8 +61,8 @@
                                     </connections>
                                 </button>
                                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="R6x-KT-PMd">
-                                    <rect key="frame" x="16" y="82" width="90" height="18"/>
-                                    <buttonCell key="cell" type="check" title="Error Icons" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="v4d-P5-Ioz">
+                                    <rect key="frame" x="16" y="82" width="98" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Show Errors" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="v4d-P5-Ioz">
                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                         <font key="font" metaFont="system"/>
                                     </buttonCell>
@@ -482,6 +248,268 @@
                                                 <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
                                             </dictionary>
                                         </binding>
+                                    </connections>
+                                </button>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7YP-ov-0Mw">
+                                    <rect key="frame" x="116" y="82" width="150" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Highlight Individually" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="0Mx-q6-zRv">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewBottom.showsIndividualErrors" id="h8O-TD-vZ2"/>
+                                        <binding destination="-2" name="enabled" keyPath="self.viewBottom.showsSyntaxErrors" id="nXe-ht-4wI"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </view>
+                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
+                        <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    </box>
+                    <box autoresizesSubviews="NO" misplaced="YES" title="Upper View" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="UbJ-ck-GAa">
+                        <rect key="frame" x="17" y="243" width="416" height="224"/>
+                        <view key="contentView">
+                            <rect key="frame" x="1" y="1" width="414" height="208"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="h9x-vk-QWV">
+                                    <rect key="frame" x="16" y="182" width="142" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Syntax Highlighting" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="CeR-vU-MuM">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.syntaxColoured" id="sd1-5m-Oey">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </button>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xQu-2v-Pd1">
+                                    <rect key="frame" x="16" y="162" width="108" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Line Numbers" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="E9f-CF-YSK">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsLineNumbers" id="S4X-7c-agd">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </button>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nJt-D9-00Z">
+                                    <rect key="frame" x="16" y="142" width="133" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Show Page Guide" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="G9A-sZ-iEl">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsPageGuide" id="S1v-Mv-O5V">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </button>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RdX-7u-GMl">
+                                    <rect key="frame" x="16" y="102" width="176" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Line Wrap at Page Guide" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="iUY-em-XBp">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="enabled" keyPath="self.viewTop.lineWrap" id="yEg-b0-iqm"/>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.lineWrapsAtPageGuide" id="GMR-8K-OsD">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </button>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YXZ-Zp-BPs">
+                                    <rect key="frame" x="16" y="82" width="98" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Show Errors" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="VCG-Ry-o24">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsSyntaxErrors" id="SqS-Gd-u55">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </button>
+                                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QYV-Lc-Kqa">
+                                    <rect key="frame" x="343" y="180" width="53" height="22"/>
+                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="iaS-d8-Frq">
+                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="ajB-Qz-3wQ"/>
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.startingLineNumber" id="AQb-eP-OPX">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEditable" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </textField>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uA5-hi-sae">
+                                    <rect key="frame" x="197" y="183" width="140" height="17"/>
+                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Starting Line Number:" id="oi7-W4-VwP">
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TBN-LA-BIG">
+                                    <rect key="frame" x="343" y="152" width="53" height="22"/>
+                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="DZK-LF-T8T">
+                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="lvY-cd-zaM"/>
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.minimumGutterWidth" id="xVR-aM-C4m">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEditable" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </textField>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhc-PU-R1S">
+                                    <rect key="frame" x="16" y="63" width="61" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Gutter" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="L8e-dj-LCp">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsGutter" id="jx8-D0-dao">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </button>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gg8-RP-10h">
+                                    <rect key="frame" x="16" y="43" width="118" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Vertical Scroller" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KYC-47-lpS">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.hasVerticalScroller" id="h7l-Iy-i2F">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </button>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LvK-DR-ay9">
+                                    <rect key="frame" x="16" y="23" width="174" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Scroll Elasticity Disabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="F7I-jJ-R7q">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.scrollElasticityDisabled" id="XI9-Om-oB5">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </button>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="znJ-t0-gXd">
+                                    <rect key="frame" x="220" y="155" width="117" height="17"/>
+                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Min. Gutter Width:" id="l6v-Gm-elJ">
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DP3-Bn-fUI">
+                                    <rect key="frame" x="343" y="123" width="53" height="22"/>
+                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="vca-Qa-xFM">
+                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="SWt-OP-Pn7"/>
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.pageGuideColumn" id="4CC-Rh-U7f">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEditable" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </textField>
+                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hxH-Dy-Yvj">
+                                    <rect key="frame" x="202" y="126" width="135" height="17"/>
+                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Page Guide Column:" id="BDb-al-XjL">
+                                        <font key="font" metaFont="system"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DDQ-O1-djJ">
+                                    <rect key="frame" x="16" y="122" width="85" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Line Wrap" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Yyj-Ay-JJt">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.lineWrap" id="UHM-cE-gJy">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                    </connections>
+                                </button>
+                                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kh1-N3-zU0">
+                                    <rect key="frame" x="116" y="82" width="150" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Highlight Individually" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Nx1-8Z-QIr">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                    <connections>
+                                        <binding destination="-2" name="value" keyPath="self.viewTop.showsIndividualErrors" id="Lth-Hg-gao">
+                                            <dictionary key="options">
+                                                <bool key="NSAllowsEditingMultipleValuesSelection" value="NO"/>
+                                                <bool key="NSConditionallySetsEnabled" value="NO"/>
+                                                <bool key="NSRaisesForNotApplicableKeys" value="NO"/>
+                                            </dictionary>
+                                        </binding>
+                                        <binding destination="-2" name="enabled" keyPath="self.viewTop.showsSyntaxErrors" id="CPn-ih-0Ci"/>
                                     </connections>
                                 </button>
                             </subviews>

--- a/MGSFragaria.m
+++ b/MGSFragaria.m
@@ -165,6 +165,20 @@ NSString * const MGSFOAutoCompleteDelegate = @"autoCompleteDelegate";
 }
 
 
+/*
+ * @propertyShowsIndividualErrors
+ */
+- (void)setShowsIndividualErrors:(BOOL)showsIndividualErrors
+{
+	self.syntaxErrorController.showsIndividualErrors = showsIndividualErrors;
+}
+
+- (BOOL)showsIndividualErrors
+{
+	return self.syntaxErrorController.showsIndividualErrors;
+}
+
+
 #pragma mark - Properties - Syntax Errors
 
 

--- a/MGSFragaria.m
+++ b/MGSFragaria.m
@@ -152,7 +152,7 @@ NSString * const MGSFOAutoCompleteDelegate = @"autoCompleteDelegate";
 
 
 /*
- * @property showsWarningsInGutter
+ * @property showsSyntaxErrors
  */
 - (void)setShowsSyntaxErrors:(BOOL)value
 {

--- a/MGSFragariaAPI.h
+++ b/MGSFragariaAPI.h
@@ -158,6 +158,10 @@
 /** Indicates whether or not error warnings are displayed.*/
 @property (nonatomic, assign) BOOL showsSyntaxErrors;
 
+/** If showing syntax errors, highlights individual errors instead of
+ * highlighting the full line. */
+@property (nonatomic, assign) BOOL showsIndividualErrors;
+
 
 #pragma mark - Showing Breakpoints
 /// @name Showing Breakpoints

--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -461,6 +461,21 @@
 }
 
 
+/*
+ * @propertyShowsIndividualErrors
+ */
+- (void)setShowsIndividualErrors:(BOOL)showsIndividualErrors
+{
+	self.fragaria.showsIndividualErrors = showsIndividualErrors;
+	[self propagateValue:@(showsIndividualErrors) forBinding:NSStringFromSelector(@selector(showsIndividualErrors))];
+}
+
+- (BOOL)showsIndividualErrors
+{
+	return self.fragaria.showsIndividualErrors;
+}
+
+
 #pragma mark - Showing Breakpoints
 
 

--- a/MGSSyntaxErrorController.h
+++ b/MGSSyntaxErrorController.h
@@ -31,6 +31,10 @@
  * view and the text view, set to NO to make all syntax errors invisible. */
 @property (nonatomic) BOOL showsSyntaxErrors;
 
+/** If showing syntax errors, highlights individual errors instead of
+ * highlighting the full line. */
+@property (nonatomic, assign) BOOL showsIndividualErrors;
+
 /** The MGSLineNumberView where to show the error decorations (icons) */
 @property (nonatomic) MGSLineNumberView *lineNumberView;
 

--- a/MGSSyntaxErrorController.m
+++ b/MGSSyntaxErrorController.m
@@ -87,6 +87,12 @@ static NSInteger CharacterIndexFromRowAndColumn(NSUInteger line, NSUInteger char
     [self updateSyntaxErrorsDisplay];
 }
 
+- (void)setShowsIndividualErrors:(BOOL)showsIndividualErrors
+{
+	_showsIndividualErrors = showsIndividualErrors;
+	[self updateSyntaxErrorsDisplay];
+}
+
 
 - (void)setLineNumberView:(MGSLineNumberView *)lineNumberView
 {
@@ -159,33 +165,63 @@ static NSInteger CharacterIndexFromRowAndColumn(NSUInteger line, NSUInteger char
     [layoutManager removeTemporaryAttribute:NSToolTipAttributeName forCharacterRange:NSMakeRange(0, text.length)];
     
     if (!self.showsSyntaxErrors) return;
-    
-    // Highlight all errors
-    NSMutableSet* highlightedRows = [NSMutableSet set];
-    
-    for (SMLSyntaxError* err in self.syntaxErrors)
-    {
-        // Highlight an erroneous line
-        NSInteger location = CharacterIndexFromRowAndColumn(err.line, err.character, text);
-        
-        // Skip lines we cannot identify in the text
-        if (location == -1) continue;
-        
-        NSRange lineRange = [text lineRangeForRange:NSMakeRange(location, 0)];
-        
-        // Highlight row if it is not already highlighted
-        if (![highlightedRows containsObject:[NSNumber numberWithUnsignedInteger:err.line]])
-        {
-            // Remember that we are highlighting this row
-            [highlightedRows addObject:[NSNumber numberWithUnsignedInteger:err.line]];
-            
-            // Add highlight for background
-            [layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:err.errorLineHighlightColor forCharacterRange:lineRange];
-            
-            if ([err.errorDescription length] > 0)
-                [layoutManager addTemporaryAttribute:NSToolTipAttributeName value:err.errorDescription forCharacterRange:lineRange];
-        }
-    }
+	
+	if (!self.showsIndividualErrors)
+	{
+		// Highlight all lines with errors
+		NSMutableSet* highlightedRows = [NSMutableSet set];
+		
+		for (SMLSyntaxError* err in self.nonHiddenErrors)
+		{
+			// Highlight an erroneous line
+			NSInteger location = CharacterIndexFromRowAndColumn(err.line, err.character, text);
+			
+			// Skip lines we cannot identify in the text
+			if (location == -1) continue;
+			
+			NSRange lineRange = [text lineRangeForRange:NSMakeRange(location, 0)];
+			
+			// Highlight row if it is not already highlighted
+			if (![highlightedRows containsObject:[NSNumber numberWithUnsignedInteger:err.line]])
+			{
+				// Remember that we are highlighting this row
+				[highlightedRows addObject:[NSNumber numberWithUnsignedInteger:err.line]];
+				
+				// Add highlight for background
+				[layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:err.errorLineHighlightColor forCharacterRange:lineRange];
+				
+				if ([err.errorDescription length] > 0)
+					[layoutManager addTemporaryAttribute:NSToolTipAttributeName value:err.errorDescription forCharacterRange:lineRange];
+			}
+		}
+	}
+	else
+	{
+		// Highlight errors individually
+		for (NSNumber *line in self.linesWithErrors)
+		{
+			// Find the erroneous line
+			NSInteger location = CharacterIndexFromRowAndColumn([line integerValue], 0, text);
+
+			// Skip lines we cannot identify in the text
+			if (location == -1) continue;
+			
+			// Highlight each individual error
+			for (SMLSyntaxError *err in [self errorsForLine:[line integerValue]])
+			{
+				// Add highlight for background
+				NSRange characterRange = NSMakeRange(location + err.character - 1, err.length);
+				
+				[layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:err.errorLineHighlightColor forCharacterRange:characterRange];
+
+				if ([err.errorDescription length] > 0)
+				{
+					[layoutManager addTemporaryAttribute:NSToolTipAttributeName value:err.errorDescription forCharacterRange:characterRange];
+				}
+			}
+
+		}
+	}
 }
 
 

--- a/MGSSyntaxErrorController.m
+++ b/MGSSyntaxErrorController.m
@@ -160,7 +160,7 @@ static NSInteger CharacterIndexFromRowAndColumn(NSUInteger line, NSUInteger char
     
     if (!self.showsSyntaxErrors) return;
     
-    // Highlight all errors and add buttjskaons
+    // Highlight all errors
     NSMutableSet* highlightedRows = [NSMutableSet set];
     
     for (SMLSyntaxError* err in self.syntaxErrors)

--- a/MGSUserDefaultsDefinitions.h
+++ b/MGSUserDefaultsDefinitions.h
@@ -53,6 +53,7 @@ extern NSString * const MGSFragariaDefaultsGutterTextColour;                    
 
 // Showing Syntax Errors
 extern NSString * const MGSFragariaDefaultsShowsSyntaxErrors;                     // BOOL       showsSyntaxErrors
+extern NSString * const MGSFragariaDefaultsShowsIndividualErrors;                 // BOOL       showsIndividualErrors
 
 // Tabulation and Indentation
 extern NSString * const MGSFragariaDefaultsTabWidth;                              // NSInteger  tabWidth

--- a/MGSUserDefaultsDefinitions.m
+++ b/MGSUserDefaultsDefinitions.m
@@ -33,7 +33,8 @@ NSString * const MGSFragariaDefaultsGutterFont =         @"gutterFont";
 NSString * const MGSFragariaDefaultsGutterTextColour =   @"gutterTextColour";
 
 // Showing Syntax Errors
-NSString * const MGSFragariaDefaultsShowsSyntaxErrors = @"showsSyntaxErrors";
+NSString * const MGSFragariaDefaultsShowsSyntaxErrors =     @"showsSyntaxErrors";
+NSString * const MGSFragariaDefaultsShowsIndividualErrors = @"showsIndividualErrors";
 
 // Tabulation and Indentation
 NSString * const MGSFragariaDefaultsTabWidth =                    @"tabWidth";
@@ -135,6 +136,7 @@ NSString * const MGSFragariaDefaultsColoursVariables =    @"coloursVariables";
 		 MGSFragariaDefaultsGutterTextColour : ARCHIVED_OBJECT([NSColor colorWithCalibratedWhite:0.42f alpha:1.0f]),
 
 		 MGSFragariaDefaultsShowsSyntaxErrors : @YES,
+		 MGSFragariaDefaultsShowsIndividualErrors : @NO,
 
 		 MGSFragariaDefaultsTabWidth : @4,
 		 MGSFragariaDefaultsIndentWidth : @4,

--- a/SMLSyntaxError.h
+++ b/SMLSyntaxError.h
@@ -89,10 +89,6 @@ extern float const kMGSErrorCategoryDefault;  ///< warningLevel = kMGSErrorCateg
 
 /** The color to use to highlight lines that have syntax errors. */
 @property (nonatomic,copy) NSColor *errorLineHighlightColor;
-/** The color to use to highlight the background of specific errors. */
-@property (nonatomic,copy) NSColor *errorBackgroundHighlightColor;
-/** The color to use to highlight the foreground of specific errors. */
-@property (nonatomic,copy) NSColor *errorForegroundHighlightColor;
 /** The warning level or severity of this syntax error. */
 @property (nonatomic,assign) float warningLevel;
 

--- a/SMLSyntaxError.m
+++ b/SMLSyntaxError.m
@@ -90,8 +90,6 @@ float const kMGSErrorCategoryDefault = 500;
     self = [super init];
     
     self.errorLineHighlightColor = [NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1];
-    self.errorBackgroundHighlightColor = [NSColor orangeColor];
-    self.errorForegroundHighlightColor = [NSColor whiteColor];
     self.line = 1;
     self.character = 1;
     self.warningLevel = kMGSErrorCategoryWarning;


### PR DESCRIPTION
Gives the option to highlight individual errors instead of entire lines.

Hmmm... I'm working on other things now, but it just occurred to me that they don't have to be mutually exclusive, although right now whole line versus individual errors is mutually exclusive. A future behaviour may be using squiggly underlines or something.This works for now, though.
