### PR TITLE
Syntax error colors

### DIFF
--- a/MGSFragaria.m
+++ b/MGSFragaria.m
@@ -196,6 +196,20 @@ NSString * const MGSFOAutoCompleteDelegate = @"autoCompleteDelegate";
 }
 
 
+/*
+ * @property defaultSyntaxErrorHighlightingColour
+ */
+- (void)setDefaultSyntaxErrorHighlightingColour:(NSColor *)defaultSyntaxErrorHighlightingColour
+{
+    self.syntaxErrorController.defaultSyntaxErrorHighlightingColour = defaultSyntaxErrorHighlightingColour;
+}
+
+-(NSColor *)defaultSyntaxErrorHighlightingColour
+{
+    return self.syntaxErrorController.defaultSyntaxErrorHighlightingColour;
+}
+
+
 #pragma mark - Properties - Delegates
 
 

--- a/MGSFragariaAPI.h
+++ b/MGSFragariaAPI.h
@@ -162,6 +162,8 @@
  * highlighting the full line. */
 @property (nonatomic, assign) BOOL showsIndividualErrors;
 
+/** The default syntax error line highlighting colour. */
+@property (nonatomic, assign) NSColor *defaultSyntaxErrorHighlightingColour;
 
 #pragma mark - Showing Breakpoints
 /// @name Showing Breakpoints

--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -476,6 +476,21 @@
 }
 
 
+/*
+ * @property defaultSyntaxErrorHighlightingColour
+ */
+- (void)setDefaultSyntaxErrorHighlightingColour:(NSColor *)defaultSyntaxErrorHighlightingColour
+{
+    self.fragaria.defaultSyntaxErrorHighlightingColour = defaultSyntaxErrorHighlightingColour;
+    [self propagateValue:defaultSyntaxErrorHighlightingColour forBinding:NSStringFromSelector(@selector(defaultSyntaxErrorHighlightingColour))];
+}
+
+-(NSColor *)defaultSyntaxErrorHighlightingColour
+{
+    return self.fragaria.defaultSyntaxErrorHighlightingColour;
+}
+
+
 #pragma mark - Showing Breakpoints
 
 

--- a/MGSSyntaxErrorController.h
+++ b/MGSSyntaxErrorController.h
@@ -35,6 +35,9 @@
  * highlighting the full line. */
 @property (nonatomic, assign) BOOL showsIndividualErrors;
 
+/** The default syntax error line highlighting colour. */
+@property (nonatomic, strong) NSColor *defaultSyntaxErrorHighlightingColour;
+
 /** The MGSLineNumberView where to show the error decorations (icons) */
 @property (nonatomic) MGSLineNumberView *lineNumberView;
 

--- a/MGSSyntaxErrorController.m
+++ b/MGSSyntaxErrorController.m
@@ -68,6 +68,7 @@ static NSInteger CharacterIndexFromRowAndColumn(NSUInteger line, NSUInteger char
 
 @implementation MGSSyntaxErrorController
 
+@synthesize defaultSyntaxErrorHighlightingColour = _defaultSyntaxErrorHighlightingColour;
 
 #pragma mark - Property Accessors
 
@@ -94,6 +95,20 @@ static NSInteger CharacterIndexFromRowAndColumn(NSUInteger line, NSUInteger char
 	[self updateSyntaxErrorsDisplay];
 }
 
+- (void)setDefaultSyntaxErrorHighlightingColour:(NSColor *)defaultSyntaxErrorHighlightingColour
+{
+    _defaultSyntaxErrorHighlightingColour = defaultSyntaxErrorHighlightingColour;
+}
+
+- (NSColor *)defaultSyntaxErrorHighlightingColour
+{
+    if (!_defaultSyntaxErrorHighlightingColour)
+    {
+        _defaultSyntaxErrorHighlightingColour = [NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1];
+    }
+
+    return _defaultSyntaxErrorHighlightingColour;
+}
 
 - (void)setLineNumberView:(MGSLineNumberView *)lineNumberView
 {
@@ -189,7 +204,8 @@ static NSInteger CharacterIndexFromRowAndColumn(NSUInteger line, NSUInteger char
             [highlightedRows addObject:[NSNumber numberWithUnsignedInteger:err.line]];
             
             // Add highlight for background
-            [layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:err.errorLineHighlightColor forCharacterRange:lineRange];
+            NSColor *highlightColor = err.errorLineHighlightColor ? err.errorLineHighlightColor : self.defaultSyntaxErrorHighlightingColour;
+            [layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName value:highlightColor forCharacterRange:lineRange];
         }
         
         NSRange errorRange = NSMakeRange(location, err.length);

--- a/MGSUserDefaultsDefinitions.h
+++ b/MGSUserDefaultsDefinitions.h
@@ -54,6 +54,7 @@ extern NSString * const MGSFragariaDefaultsGutterTextColour;                    
 // Showing Syntax Errors
 extern NSString * const MGSFragariaDefaultsShowsSyntaxErrors;                     // BOOL       showsSyntaxErrors
 extern NSString * const MGSFragariaDefaultsShowsIndividualErrors;                 // BOOL       showsIndividualErrors
+extern NSString * const MGSFragariaDefaultsDefaultErrorHighlightingColor;         // NSColor    defaultSyntaxErrorHighlightingColour
 
 // Tabulation and Indentation
 extern NSString * const MGSFragariaDefaultsTabWidth;                              // NSInteger  tabWidth

--- a/MGSUserDefaultsDefinitions.m
+++ b/MGSUserDefaultsDefinitions.m
@@ -33,8 +33,9 @@ NSString * const MGSFragariaDefaultsGutterFont =         @"gutterFont";
 NSString * const MGSFragariaDefaultsGutterTextColour =   @"gutterTextColour";
 
 // Showing Syntax Errors
-NSString * const MGSFragariaDefaultsShowsSyntaxErrors =     @"showsSyntaxErrors";
-NSString * const MGSFragariaDefaultsShowsIndividualErrors = @"showsIndividualErrors";
+NSString * const MGSFragariaDefaultsShowsSyntaxErrors =             @"showsSyntaxErrors";
+NSString * const MGSFragariaDefaultsShowsIndividualErrors =         @"showsIndividualErrors";
+NSString * const MGSFragariaDefaultsDefaultErrorHighlightingColor = @"defaultSyntaxErrorHighlightingColour";
 
 // Tabulation and Indentation
 NSString * const MGSFragariaDefaultsTabWidth =                    @"tabWidth";
@@ -137,6 +138,7 @@ NSString * const MGSFragariaDefaultsColoursVariables =    @"coloursVariables";
 
 		 MGSFragariaDefaultsShowsSyntaxErrors : @YES,
 		 MGSFragariaDefaultsShowsIndividualErrors : @NO,
+         MGSFragariaDefaultsDefaultErrorHighlightingColor : ARCHIVED_COLOR(1.0f, 1.0f, 0.7f),
 
 		 MGSFragariaDefaultsTabWidth : @4,
 		 MGSFragariaDefaultsIndentWidth : @4,

--- a/SMLSyntaxError.m
+++ b/SMLSyntaxError.m
@@ -89,7 +89,6 @@ float const kMGSErrorCategoryDefault = 500;
 {
     self = [super init];
     
-    self.errorLineHighlightColor = [NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1];
     self.line = 1;
     self.character = 1;
     self.warningLevel = kMGSErrorCategoryWarning;


### PR DESCRIPTION
Per the commit messages, this makes the default error line highlighting color potentially user-controlled via preferences.
