### PR TITLE
Make the Fragaria target shared

### DIFF
--- a/Fragaria.xcodeproj/xcshareddata/xcschemes/Fragaria.xcscheme
+++ b/Fragaria.xcodeproj/xcshareddata/xcschemes/Fragaria.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB69B62A118B745700903D1D"
+               BuildableName = "Fragaria.framework"
+               BlueprintName = "Fragaria"
+               ReferencedContainer = "container:Fragaria.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D0E5210C1A90E34F005CB80B"
+               BuildableName = "Fragaria Tests.xctest"
+               BlueprintName = "Fragaria Tests"
+               ReferencedContainer = "container:Fragaria.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB69B62A118B745700903D1D"
+            BuildableName = "Fragaria.framework"
+            BlueprintName = "Fragaria"
+            ReferencedContainer = "container:Fragaria.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB69B62A118B745700903D1D"
+            BuildableName = "Fragaria.framework"
+            BlueprintName = "Fragaria"
+            ReferencedContainer = "container:Fragaria.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB69B62A118B745700903D1D"
+            BuildableName = "Fragaria.framework"
+            BlueprintName = "Fragaria"
+            ReferencedContainer = "container:Fragaria.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MGSFragaria-Info.plist
+++ b/MGSFragaria-Info.plist
@@ -13,10 +13,10 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 </dict>
 </plist>

--- a/MGSFragariaView.h
+++ b/MGSFragariaView.h
@@ -310,6 +310,20 @@
 /** Specifies the colour to render invisible characters in the text view.*/
 @property (nonatomic, assign, nonnull) NSColor *textInvisibleCharactersColour;
 
+/**
+ *  Clears the current substitutes for invisible characters
+ **/
+- (void)clearInvisibleCharacterSubstitutes;
+
+/**
+ *  Remove the substitute for invisible character `character`
+ **/
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character;
+
+/**
+ *  Add a substitute `substitute` for invisible character `character`
+ **/
+- (void)addSubstitute:(NSString * _Nonnull)substitute forInvisibleCharacter:(unichar)character;
 
 #pragma mark - Configuring Text Appearance
 /// @name Configuring Text Appearance

--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -794,6 +794,20 @@
 	return self.textView.textInvisibleCharactersColour;
 }
 
+- (void)clearInvisibleCharacterSubstitutes
+{
+    [self.textView clearInvisibleCharacterSubstitutes];
+}
+
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character
+{
+    [self.textView removeSubstituteForInvisibleCharacter:character];
+}
+
+- (void)addSubstitute:(NSString * _Nonnull)substitute forInvisibleCharacter:(unichar)character
+{
+    [self.textView addSubstitute:substitute forInvisibleCharacter:character];
+}
 
 #pragma mark - Configuring Text Appearance
 

--- a/SMLLayoutManager.h
+++ b/SMLLayoutManager.h
@@ -57,5 +57,19 @@ enum {
  **/
 @property BOOL showsInvisibleCharacters;
 
+/**
+ *  Clears the current substitutes for invisible characters
+ **/
+- (void)clearInvisibleCharacterSubstitutes;
+
+/**
+ *  Remove the substitute for invisible character `character`
+ **/
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character;
+
+/**
+ *  Add a substitute `substitute` for invisible character `character`
+ **/
+- (void)addSubstitute:(NSString*)substitute forInvisibleCharacter:(unichar)character;
 
 @end

--- a/SMLTextView.h
+++ b/SMLTextView.h
@@ -209,6 +209,20 @@
 /** Specifies the colour to render invisible characters in the text view.*/
 @property (nonatomic, assign) NSColor *textInvisibleCharactersColour;
 
+/**
+ *  Clears the current substitutes for invisible characters
+ **/
+- (void)clearInvisibleCharacterSubstitutes;
+
+/**
+ *  Remove the substitute for invisible character `character`
+ **/
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character;
+
+/**
+ *  Add a substitute `substitute` for invisible character `character`
+ **/
+- (void)addSubstitute:(NSString *)substitute forInvisibleCharacter:(unichar)character;
 
 #pragma mark - Configuring Text Appearance
 /// @name Configuring Text Appearance

--- a/SMLTextView.m
+++ b/SMLTextView.m
@@ -128,6 +128,20 @@ static unichar ClosingBraceForOpeningBrace(unichar c)
 	return self.layoutManager.showsInvisibleCharacters;
 }
 
+- (void)clearInvisibleCharacterSubstitutes
+{
+    [self.layoutManager clearInvisibleCharacterSubstitutes];
+}
+
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character
+{
+    [self.layoutManager removeSubstituteForInvisibleCharacter:character];
+}
+
+- (void)addSubstitute:(NSString * _Nonnull)substitute forInvisibleCharacter:(unichar)character
+{
+    [self.layoutManager addSubstitute:substitute forInvisibleCharacter:character];
+}
 
 /*
  * @property lineSpacing


### PR DESCRIPTION
This allows Fragaria to be used by Carthage.

To follow the convention used by Carthage, a tag (ex: 1.0) would be useful. This would eliminate the need to use a commit hash to specify a specific revision of the code.