### PR TITLE
Add support to customize invisible character substitutions

### DIFF
--- a/MGSFragariaView.h
+++ b/MGSFragariaView.h
@@ -310,6 +310,20 @@
 /** Specifies the colour to render invisible characters in the text view.*/
 @property (nonatomic, assign, nonnull) NSColor *textInvisibleCharactersColour;
 
+/**
+ *  Clears the current substitutes for invisible characters
+ **/
+- (void)clearInvisibleCharacterSubstitutes;
+
+/**
+ *  Remove the substitute for invisible character `character`
+ **/
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character;
+
+/**
+ *  Add a substitute `substitute` for invisible character `character`
+ **/
+- (void)addSubstitute:(NSString * _Nonnull)substitute forInvisibleCharacter:(unichar)character;
 
 #pragma mark - Configuring Text Appearance
 /// @name Configuring Text Appearance

--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -794,6 +794,20 @@
 	return self.textView.textInvisibleCharactersColour;
 }
 
+- (void)clearInvisibleCharacterSubstitutes
+{
+    [self.textView clearInvisibleCharacterSubstitutes];
+}
+
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character
+{
+    [self.textView removeSubstituteForInvisibleCharacter:character];
+}
+
+- (void)addSubstitute:(NSString * _Nonnull)substitute forInvisibleCharacter:(unichar)character
+{
+    [self.textView addSubstitute:substitute forInvisibleCharacter:character];
+}
 
 #pragma mark - Configuring Text Appearance
 

--- a/SMLLayoutManager.h
+++ b/SMLLayoutManager.h
@@ -57,5 +57,19 @@ enum {
  **/
 @property BOOL showsInvisibleCharacters;
 
+/**
+ *  Clears the current substitutes for invisible characters
+ **/
+- (void)clearInvisibleCharacterSubstitutes;
+
+/**
+ *  Remove the substitute for invisible character `character`
+ **/
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character;
+
+/**
+ *  Add a substitute `substitute` for invisible character `character`
+ **/
+- (void)addSubstitute:(NSString*)substitute forInvisibleCharacter:(unichar)character;
 
 @end

--- a/SMLTextView.h
+++ b/SMLTextView.h
@@ -209,6 +209,20 @@
 /** Specifies the colour to render invisible characters in the text view.*/
 @property (nonatomic, assign) NSColor *textInvisibleCharactersColour;
 
+/**
+ *  Clears the current substitutes for invisible characters
+ **/
+- (void)clearInvisibleCharacterSubstitutes;
+
+/**
+ *  Remove the substitute for invisible character `character`
+ **/
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character;
+
+/**
+ *  Add a substitute `substitute` for invisible character `character`
+ **/
+- (void)addSubstitute:(NSString *)substitute forInvisibleCharacter:(unichar)character;
 
 #pragma mark - Configuring Text Appearance
 /// @name Configuring Text Appearance

--- a/SMLTextView.m
+++ b/SMLTextView.m
@@ -128,6 +128,20 @@ static unichar ClosingBraceForOpeningBrace(unichar c)
 	return self.layoutManager.showsInvisibleCharacters;
 }
 
+- (void)clearInvisibleCharacterSubstitutes
+{
+    [self.layoutManager clearInvisibleCharacterSubstitutes];
+}
+
+- (void)removeSubstituteForInvisibleCharacter:(unichar)character
+{
+    [self.layoutManager removeSubstituteForInvisibleCharacter:character];
+}
+
+- (void)addSubstitute:(NSString * _Nonnull)substitute forInvisibleCharacter:(unichar)character
+{
+    [self.layoutManager addSubstitute:substitute forInvisibleCharacter:character];
+}
 
 /*
  * @property lineSpacing


### PR DESCRIPTION
It allows more flexibility of which invisible characters can be shown to the user. For example, I like to show to the users, their use of the _non break space_. 