### PR TITLE
When text in the NSTextView changes, propagate the change to bindings

### DIFF
--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -1273,6 +1273,18 @@
 	[self setShowsSyntaxErrors:YES];
 	
 	[self setAutoCompleteDelegate:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textDidChange:) name:NSTextDidChangeNotification object:self.textView];
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)textDidChange:(NSNotification *)notification
+{
+    [self mgs_propagateValue:self.string forBinding:NSStringFromSelector(@selector(string))];
 }
 
 


### PR DESCRIPTION
Perhaps I'm doing something wrong, but MGSFragariaView doesn't appear to update its bindings when the text in the internal NSTextView changes.

With this PR, bound objects will immediately be notified as the contents of the NSTextView change.