### PR TITLE
If you setString: to nil, the application will crash

### DIFF
--- a/MGSFragariaView.m
+++ b/MGSFragariaView.m
@@ -103,7 +103,7 @@
  */
 - (void)setString:(NSString *)string
 {
-	self.textView.string = string;
+    self.textView.string = string ?: @"";
     [self mgs_propagateValue:string forBinding:NSStringFromSelector(@selector(string))];
 }
 


### PR DESCRIPTION
I found that when using bindings, my properties were initially set to `nil` until they were initialised. When this happened, my application would crash because NSTextView won't accept a `nil` string value.

This PR sets an empty string on NSTextView when `nil` is provided.