### PR TITLE
Fix for Carthage.

### DIFF
--- a/Fragaria.xcodeproj/xcshareddata/xcschemes/FragariaDefaultsCoordinator.xcscheme
+++ b/Fragaria.xcodeproj/xcshareddata/xcschemes/FragariaDefaultsCoordinator.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1110"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "01919E22217D20A800E26B9D"
+               BuildableName = "FragariaDefaultsCoordinator.framework"
+               BlueprintName = "FragariaDefaultsCoordinator"
+               ReferencedContainer = "container:Fragaria.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "01919E2A217D20A800E26B9D"
+               BuildableName = "FragariaDefaultsCoordinatorTests.xctest"
+               BlueprintName = "FragariaDefaultsCoordinatorTests"
+               ReferencedContainer = "container:Fragaria.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "01919E22217D20A800E26B9D"
+            BuildableName = "FragariaDefaultsCoordinator.framework"
+            BlueprintName = "FragariaDefaultsCoordinator"
+            ReferencedContainer = "container:Fragaria.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Carthage is a dependency collector ("manager" is too strong a word) that builds
dependencies as needed, while making it simple to keep the binaries out of version
control (thus inflating their sizes).

Carthage only builds schemes from Xcode projects that are marked "shared", and there is
no other configuration possible. Although the FragariaDefaultsCoordinator scheme _is_
marked shared, for some reason the `FragariaDefaultsCoordinator.xcscheme` is missing from
`xcshareddata/xcschemes/`.

This fix includes this file so that Carthage can build the Defaults Coordinator scheme,
and it was generated by checking and then unchecking the "shared" button in Xcode's
scheme manager.