### PR TITLE
Make it possible to hide the separator line

### DIFF
--- a/Fragaria/MGSFragariaView.h
+++ b/Fragaria/MGSFragariaView.h
@@ -199,6 +199,9 @@ IB_DESIGNABLE
 /** Specifies the starting line number in the text view.*/
 @property (nonatomic, assign) NSUInteger startingLineNumber;
 
+/** Indicates whether or not the separator are displayed when the gutter is visible.*/
+@property (nonatomic, assign) BOOL showsGutterSeparator;
+
 /** Specifies the standard font for the line numbers in the gutter.*/
 @property (nonatomic, assign) IBInspectable NSFont *gutterFont;
 /** Specifies the standard color of the line numbers in the gutter.*/

--- a/Fragaria/MGSFragariaView.m
+++ b/Fragaria/MGSFragariaView.m
@@ -423,6 +423,21 @@
 
 
 /*
+ * @property showsLineNumbers
+ */
+- (void)setShowsGutterSeparator:(BOOL)showsGutterSeparator
+{
+    self.gutterView.showsSeparator = showsGutterSeparator;
+    [self mgs_propagateValue:@(showsGutterSeparator) forBinding:NSStringFromSelector(@selector(showsGutterSeparator))];
+}
+
+- (BOOL)showsGutterSeparator
+{
+    return self.gutterView.showsSeparator;
+}
+
+
+/*
  * @property gutterFont
  */
 - (void)setGutterFont:(NSFont *)gutterFont

--- a/Fragaria/MGSLineNumberView.h
+++ b/Fragaria/MGSLineNumberView.h
@@ -89,6 +89,8 @@
 /** Indicates whether or not line numbers should be drawn. */
 @property (nonatomic, assign) BOOL showsLineNumbers;
 
+/** Indicates whether or not the separator should be drawn. */
+@property (nonatomic, assign) BOOL showsSeparator;
 
 /// @name Instance Methods
 

--- a/Fragaria/MGSLineNumberView.m
+++ b/Fragaria/MGSLineNumberView.m
@@ -447,8 +447,6 @@ typedef enum {
 
 - (void)drawBackgroundInRect:(NSRect)dirtyRect
 {
-    if (!_showsSeparator)
-        return;
     NSRect bounds, visibleRect;
     NSBezierPath *dottedLine;
     NSColor *dotColor, *borderColor;
@@ -459,6 +457,9 @@ typedef enum {
     
     [self.backgroundColor set];
     NSRectFill(bounds);
+    
+    if (!_showsSeparator)
+        return;
     
     borderColor = [self.backgroundColor blendedColorWithFraction:.5 ofColor:self.clientView.backgroundColor];
     dotColor = [NSColor darkGrayColor];

--- a/Fragaria/MGSLineNumberView.m
+++ b/Fragaria/MGSLineNumberView.m
@@ -87,6 +87,7 @@ typedef enum {
         _fragaria = fragaria;
         
         _showsLineNumbers = YES;
+        _showsSeparator = YES;
         _backgroundColor = [NSColor controlBackgroundColor];
         _minimumWidth = 40;
         
@@ -138,6 +139,13 @@ typedef enum {
 - (void)setShowsLineNumbers:(BOOL)drawsLineNumbers
 {
     _showsLineNumbers = drawsLineNumbers;
+    [self setRuleThickness:[self requiredThickness]];
+    [self setNeedsDisplay:YES];
+}
+
+- (void)setShowsSeparator:(BOOL)showsSeparator
+{
+    _showsSeparator = showsSeparator;
     [self setRuleThickness:[self requiredThickness]];
     [self setNeedsDisplay:YES];
 }
@@ -439,6 +447,8 @@ typedef enum {
 
 - (void)drawBackgroundInRect:(NSRect)dirtyRect
 {
+    if (!_showsSeparator)
+        return;
     NSRect bounds, visibleRect;
     NSBezierPath *dottedLine;
     NSColor *dotColor, *borderColor;


### PR DESCRIPTION
Hiding the separator line makes the text view more visually similar to the one in Xcode. 