### PR TITLE
Fix automatic dark/light mode switch

### DIFF
--- a/Fragaria/Images.xcassets/Attribute.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/Attribute.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.500",
+          "red" : "0.500"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.500",
+          "red" : "0.500"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/AutoComplete.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/AutoComplete.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.006",
+          "green" : "0.410",
+          "red" : "0.840"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.006",
+          "green" : "0.410",
+          "red" : "0.840"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/Command.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/Command.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.855",
+          "green" : "0.000",
+          "red" : "0.031"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.855",
+          "green" : "0.000",
+          "red" : "0.031"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/Comment.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/Comment.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.450",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.271",
+          "green" : "0.800",
+          "red" : "0.255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/Contents.json
+++ b/Fragaria/Images.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Fragaria/Images.xcassets/DefaultErrorHighlighting.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/DefaultErrorHighlighting.colorset/Contents.json
@@ -1,0 +1,36 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.700",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "gray-gamma-22",
+        "components" : {
+          "alpha" : "1.000",
+          "white" : "0.400"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/Instruction.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/Instruction.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.647",
+          "green" : "0.450",
+          "red" : "0.737"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.647",
+          "green" : "0.450",
+          "red" : "0.737"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/KeyCurrentLineHighlight.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/KeyCurrentLineHighlight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.710",
+          "green" : "0.960",
+          "red" : "0.960"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/Keyword.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/Keyword.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.647",
+          "green" : "0.450",
+          "red" : "0.737"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.580",
+          "green" : "0.094",
+          "red" : "0.827"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/Number.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/Number.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.855",
+          "green" : "0.000",
+          "red" : "0.031"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.427",
+          "red" : "0.467"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/String.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/String.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.153",
+          "green" : "0.071",
+          "red" : "0.804"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.220",
+          "green" : "0.173",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/TextInvisibleCharacters.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/TextInvisibleCharacters.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.906",
+          "green" : "0.906",
+          "red" : "0.906"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/Images.xcassets/Variable.colorset/Contents.json
+++ b/Fragaria/Images.xcassets/Variable.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.740",
+          "green" : "0.000",
+          "red" : "0.730"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.740",
+          "green" : "0.000",
+          "red" : "0.730"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Fragaria/MGSColourScheme.h
+++ b/Fragaria/MGSColourScheme.h
@@ -89,6 +89,8 @@ extern MGSColourSchemeGroupOptionKey MGSColourSchemeGroupOptionKeyFontVariant;
  * @param appearance The appearance appropriate for the returned scheme */
 + (instancetype)defaultColorSchemeForAppearance:(NSAppearance *)appearance;
 
+/** Returns a colour scheme instance with colours that switch dynamically from dark to white mode. */
++ (instancetype)dynamicColorBuiltinColourScheme;
 
 #pragma mark - Saving Colour Schemes
 /// @name Saving Loading Colour Schemes

--- a/Fragaria/MGSColourScheme.m
+++ b/Fragaria/MGSColourScheme.m
@@ -132,6 +132,113 @@ static NSString * const KMGSColourSchemeExt = @"plist";
 
 #pragma mark - Default Color Schemes
 
++ (NSColor*) defaultErrorHighlightingColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"DefaultErrorHighlighting" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1];
+	}
+}
+
++ (NSColor*) textInvisibleCharactersColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"TextInvisibleCharacters" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor blackColor];
+	}
+}
+
++ (NSColor*) keyCurrentLineHighlightColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"KeyCurrentLineHighlight" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor blackColor];
+	}
+}
+
++ (NSColor*) autoCompleteColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"AutoComplete" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:0.84f green:0.41f blue:0.006f alpha:1.0];
+	}
+}
+
++ (NSColor*) attributeColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"Attribute" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:0.50f green:0.5f blue:0.2f alpha:1.0];
+	}
+}
+
++ (NSColor*) commandColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"Command" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0];
+	}
+}
+
++ (NSColor*) commentColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"Comment" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:0.0f green:0.45f blue:0.0f alpha:1.0];
+	}
+}
+
++ (NSColor*) instructionColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"Instruction" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0];
+	}
+}
+
++ (NSColor*) keywordColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"Keyword" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0];
+	}
+}
+
++ (NSColor*) numberColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"Number" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0];
+	}
+}
+
++ (NSColor*) stringColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"String" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:0.804f green:0.071f blue:0.153f alpha:1.0];
+	}
+}
+
++ (NSColor*) variableColor
+{
+	if (@available(macOS 10.13, *)) {
+		return [NSColor colorNamed:@"Variable" bundle:[NSBundle bundleForClass:self]];
+	} else {
+		return [NSColor colorWithCalibratedRed:0.73f green:0.0f blue:0.74f alpha:1.0];
+	}
+}
 
 + (instancetype)defaultColorSchemeForAppearance:(NSAppearance *)appearance
 {
@@ -190,52 +297,24 @@ static NSString * const KMGSColourSchemeExt = @"plist";
         MGSSyntaxGroupNumber        : @YES,
         MGSSyntaxGroupString        : @YES,
         MGSSyntaxGroupVariable      : @YES};
-    
-    BOOL dark = NO;
-    if (@available(macOS 10.14.0, *)) {
-        NSString *best = [appearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
-        dark = [best isEqual:NSAppearanceNameDarkAqua];
-    }
-    
-    NSDictionary *colors;
-    NSDictionary *groupColors;
-    if (!dark) {
-        colors = @{
-            MGSColourSchemeKeyDefaultErrorHighlightingColor : [NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1],
-            MGSColourSchemeKeyTextInvisibleCharactersColour : [NSColor blackColor],
-            MGSColourSchemeKeyTextColor                     : [NSColor blackColor],
-            MGSColourSchemeKeyBackgroundColor               : [NSColor whiteColor],
-            MGSColourSchemeKeyInsertionPointColor           : [NSColor blackColor],
-            MGSColourSchemeKeyCurrentLineHighlightColour    : [NSColor colorWithCalibratedRed:0.96f green:0.96f blue:0.71f alpha:1.0]};
-        groupColors = @{
-            MGSSyntaxGroupAutoComplete : [NSColor colorWithCalibratedRed:0.84f green:0.41f blue:0.006f alpha:1.0],
-            MGSSyntaxGroupAttribute    : [NSColor colorWithCalibratedRed:0.50f green:0.5f blue:0.2f alpha:1.0],
-            MGSSyntaxGroupCommand      : [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0],
-            MGSSyntaxGroupComment      : [NSColor colorWithCalibratedRed:0.0f green:0.45f blue:0.0f alpha:1.0],
-            MGSSyntaxGroupInstruction  : [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0],
-            MGSSyntaxGroupKeyword      : [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0],
-            MGSSyntaxGroupNumber       : [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0],
-            MGSSyntaxGroupString       : [NSColor colorWithCalibratedRed:0.804f green:0.071f blue:0.153f alpha:1.0],
-            MGSSyntaxGroupVariable     : [NSColor colorWithCalibratedRed:0.73f green:0.0f blue:0.74f alpha:1.0]};
-    } else {
-        colors = @{
-            MGSColourSchemeKeyDefaultErrorHighlightingColor : [NSColor colorWithCalibratedWhite:0.4 alpha:1.0],
-            MGSColourSchemeKeyTextInvisibleCharactersColour : [NSColor colorWithCalibratedRed:0.905882f green:0.905882f blue:0.905882f alpha:1.0],
-            MGSColourSchemeKeyTextColor                     : [NSColor whiteColor],
-            MGSColourSchemeKeyBackgroundColor               : [NSColor blackColor],
-            MGSColourSchemeKeyInsertionPointColor           : [NSColor whiteColor],
-            MGSColourSchemeKeyCurrentLineHighlightColour    : [NSColor blackColor]};
-        groupColors = @{
-            MGSSyntaxGroupAutoComplete : [NSColor colorWithCalibratedRed:0.84f green:0.41f blue:0.006f alpha:1.0],
-            MGSSyntaxGroupAttribute    : [NSColor colorWithCalibratedRed:0.5f green:0.5f blue:0.2f alpha:1.0],
-            MGSSyntaxGroupCommand      : [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0],
-            MGSSyntaxGroupComment      : [NSColor colorWithCalibratedRed:0.254902f green:0.8f blue:0.270588f alpha:1.0],
-            MGSSyntaxGroupInstruction  : [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0],
-            MGSSyntaxGroupKeyword      : [NSColor colorWithCalibratedRed:0.827451f green:0.094118f blue:0.580392f alpha:1.0],
-            MGSSyntaxGroupNumber       : [NSColor colorWithCalibratedRed:0.466667f green:0.427451f blue:1.0f alpha:1.0],
-            MGSSyntaxGroupString       : [NSColor colorWithCalibratedRed:1.0f green:0.172549f blue:0.219608f alpha:1.0],
-            MGSSyntaxGroupVariable     : [NSColor colorWithCalibratedRed:0.73f green:0.0f blue:0.74f alpha:1.0]};
-    }
+        
+	NSDictionary *colors = @{
+		MGSColourSchemeKeyDefaultErrorHighlightingColor : [self defaultErrorHighlightingColor],
+		MGSColourSchemeKeyTextInvisibleCharactersColour : [self textInvisibleCharactersColor],
+		MGSColourSchemeKeyTextColor                     : [NSColor textColor],
+		MGSColourSchemeKeyBackgroundColor               : [NSColor textBackgroundColor],
+		MGSColourSchemeKeyInsertionPointColor           : [NSColor textColor],
+		MGSColourSchemeKeyCurrentLineHighlightColour    : [self keyCurrentLineHighlightColor]};
+	NSDictionary *groupColors = @{
+		MGSSyntaxGroupAutoComplete : [self autoCompleteColor],
+		MGSSyntaxGroupAttribute    : [self attributeColor],
+		MGSSyntaxGroupCommand      : [self commandColor],
+		MGSSyntaxGroupComment      : [self commentColor],
+		MGSSyntaxGroupInstruction  : [self instructionColor],
+		MGSSyntaxGroupKeyword      : [self keywordColor],
+		MGSSyntaxGroupNumber       : [self numberColor],
+		MGSSyntaxGroupString       : [self stringColor],
+		MGSSyntaxGroupVariable     : [self variableColor]};
     
     [common addEntriesFromDictionary:colors];
     NSMutableDictionary *groups = [NSMutableDictionary dictionary];

--- a/Fragaria/MGSColourScheme.m
+++ b/Fragaria/MGSColourScheme.m
@@ -132,119 +132,20 @@ static NSString * const KMGSColourSchemeExt = @"plist";
 
 #pragma mark - Default Color Schemes
 
-+ (NSColor*) defaultErrorHighlightingColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"DefaultErrorHighlighting" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1];
-	}
-}
-
-+ (NSColor*) textInvisibleCharactersColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"TextInvisibleCharacters" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor blackColor];
-	}
-}
-
-+ (NSColor*) keyCurrentLineHighlightColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"KeyCurrentLineHighlight" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor blackColor];
-	}
-}
-
-+ (NSColor*) autoCompleteColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"AutoComplete" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:0.84f green:0.41f blue:0.006f alpha:1.0];
-	}
-}
-
-+ (NSColor*) attributeColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"Attribute" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:0.50f green:0.5f blue:0.2f alpha:1.0];
-	}
-}
-
-+ (NSColor*) commandColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"Command" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0];
-	}
-}
-
-+ (NSColor*) commentColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"Comment" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:0.0f green:0.45f blue:0.0f alpha:1.0];
-	}
-}
-
-+ (NSColor*) instructionColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"Instruction" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0];
-	}
-}
-
-+ (NSColor*) keywordColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"Keyword" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0];
-	}
-}
-
-+ (NSColor*) numberColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"Number" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0];
-	}
-}
-
-+ (NSColor*) stringColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"String" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:0.804f green:0.071f blue:0.153f alpha:1.0];
-	}
-}
-
-+ (NSColor*) variableColor
-{
-	if (@available(macOS 10.13, *)) {
-		return [NSColor colorNamed:@"Variable" bundle:[NSBundle bundleForClass:self]];
-	} else {
-		return [NSColor colorWithCalibratedRed:0.73f green:0.0f blue:0.74f alpha:1.0];
-	}
-}
 
 + (instancetype)defaultColorSchemeForAppearance:(NSAppearance *)appearance
 {
     return [[self alloc] initWithDictionary:[self defaultValuesForAppearance:appearance]];
 }
 
++ (instancetype)dynamicColorBuiltinColourScheme
+{
+	if (@available(macOS 10.13, *)) {
+		return [[self alloc] initWithDictionary:[self defaultValuesForDynamicColor]];
+	} else {
+		return [self defaultColorSchemeForAppearance:[NSAppearance currentAppearance]];
+	}
+}
 
 + (NSArray <MGSColourScheme *> *)builtinColourSchemes
 {
@@ -297,24 +198,106 @@ static NSString * const KMGSColourSchemeExt = @"plist";
         MGSSyntaxGroupNumber        : @YES,
         MGSSyntaxGroupString        : @YES,
         MGSSyntaxGroupVariable      : @YES};
+    
+    BOOL dark = NO;
+    if (@available(macOS 10.14.0, *)) {
+        NSString *best = [appearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+        dark = [best isEqual:NSAppearanceNameDarkAqua];
+    }
+    
+    NSDictionary *colors;
+    NSDictionary *groupColors;
+    if (!dark) {
+        colors = @{
+            MGSColourSchemeKeyDefaultErrorHighlightingColor : [NSColor colorWithCalibratedRed:1 green:1 blue:0.7 alpha:1],
+            MGSColourSchemeKeyTextInvisibleCharactersColour : [NSColor blackColor],
+            MGSColourSchemeKeyTextColor                     : [NSColor blackColor],
+            MGSColourSchemeKeyBackgroundColor               : [NSColor whiteColor],
+            MGSColourSchemeKeyInsertionPointColor           : [NSColor blackColor],
+            MGSColourSchemeKeyCurrentLineHighlightColour    : [NSColor colorWithCalibratedRed:0.96f green:0.96f blue:0.71f alpha:1.0]};
+        groupColors = @{
+            MGSSyntaxGroupAutoComplete : [NSColor colorWithCalibratedRed:0.84f green:0.41f blue:0.006f alpha:1.0],
+            MGSSyntaxGroupAttribute    : [NSColor colorWithCalibratedRed:0.50f green:0.5f blue:0.2f alpha:1.0],
+            MGSSyntaxGroupCommand      : [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0],
+            MGSSyntaxGroupComment      : [NSColor colorWithCalibratedRed:0.0f green:0.45f blue:0.0f alpha:1.0],
+            MGSSyntaxGroupInstruction  : [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0],
+            MGSSyntaxGroupKeyword      : [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0],
+            MGSSyntaxGroupNumber       : [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0],
+            MGSSyntaxGroupString       : [NSColor colorWithCalibratedRed:0.804f green:0.071f blue:0.153f alpha:1.0],
+            MGSSyntaxGroupVariable     : [NSColor colorWithCalibratedRed:0.73f green:0.0f blue:0.74f alpha:1.0]};
+    } else {
+        colors = @{
+            MGSColourSchemeKeyDefaultErrorHighlightingColor : [NSColor colorWithCalibratedWhite:0.4 alpha:1.0],
+            MGSColourSchemeKeyTextInvisibleCharactersColour : [NSColor colorWithCalibratedRed:0.905882f green:0.905882f blue:0.905882f alpha:1.0],
+            MGSColourSchemeKeyTextColor                     : [NSColor whiteColor],
+            MGSColourSchemeKeyBackgroundColor               : [NSColor blackColor],
+            MGSColourSchemeKeyInsertionPointColor           : [NSColor whiteColor],
+            MGSColourSchemeKeyCurrentLineHighlightColour    : [NSColor blackColor]};
+        groupColors = @{
+            MGSSyntaxGroupAutoComplete : [NSColor colorWithCalibratedRed:0.84f green:0.41f blue:0.006f alpha:1.0],
+            MGSSyntaxGroupAttribute    : [NSColor colorWithCalibratedRed:0.5f green:0.5f blue:0.2f alpha:1.0],
+            MGSSyntaxGroupCommand      : [NSColor colorWithCalibratedRed:0.031f green:0.0f blue:0.855f alpha:1.0],
+            MGSSyntaxGroupComment      : [NSColor colorWithCalibratedRed:0.254902f green:0.8f blue:0.270588f alpha:1.0],
+            MGSSyntaxGroupInstruction  : [NSColor colorWithCalibratedRed:0.737f green:0.0f blue:0.647f alpha:1.0],
+            MGSSyntaxGroupKeyword      : [NSColor colorWithCalibratedRed:0.827451f green:0.094118f blue:0.580392f alpha:1.0],
+            MGSSyntaxGroupNumber       : [NSColor colorWithCalibratedRed:0.466667f green:0.427451f blue:1.0f alpha:1.0],
+            MGSSyntaxGroupString       : [NSColor colorWithCalibratedRed:1.0f green:0.172549f blue:0.219608f alpha:1.0],
+            MGSSyntaxGroupVariable     : [NSColor colorWithCalibratedRed:0.73f green:0.0f blue:0.74f alpha:1.0]};
+    }
+    
+    [common addEntriesFromDictionary:colors];
+    NSMutableDictionary *groups = [NSMutableDictionary dictionary];
+    for (NSString *group in commonEnabled) {
+        NSDictionary *options = @{
+            MGSColourSchemeGroupOptionKeyEnabled: commonEnabled[group],
+            MGSColourSchemeGroupOptionKeyColour:  groupColors[group]};
+        [groups setObject:options forKey:group];
+    }
+    [common setObject:groups forKey:MGSColourSchemeKeySyntaxGroupOptions];
+    return [common copy];
+}
+
+
+// private
++ (NSDictionary *)defaultValuesForDynamicColor API_AVAILABLE(macosx(10.13))
+{
+    NSString *dispName = NSLocalizedStringFromTableInBundle(
+            @"Custom Settings", nil, [NSBundle bundleForClass:[self class]],
+            @"Name for Custom Settings scheme.");
+    NSMutableDictionary *common = [@{
+            MGSColourSchemeKeyDisplayName                        : dispName,
+            MGSColourSchemeKeySelectionBackgroundColor           : [NSColor selectedTextBackgroundColor],
+            MGSColourSchemeKeyGutterTextColor                    : [NSColor disabledControlTextColor],
+            MGSColourSchemeKeyGutterBackgroundColor              : [NSColor controlBackgroundColor]}
+        mutableCopy];
+    NSDictionary *commonEnabled = @{
+        MGSSyntaxGroupAttribute     : @YES,
+        MGSSyntaxGroupAutoComplete  : @NO,
+        MGSSyntaxGroupCommand       : @YES,
+        MGSSyntaxGroupComment       : @YES,
+        MGSSyntaxGroupInstruction   : @YES,
+        MGSSyntaxGroupKeyword       : @YES,
+        MGSSyntaxGroupNumber        : @YES,
+        MGSSyntaxGroupString        : @YES,
+        MGSSyntaxGroupVariable      : @YES};
         
 	NSDictionary *colors = @{
-		MGSColourSchemeKeyDefaultErrorHighlightingColor : [self defaultErrorHighlightingColor],
-		MGSColourSchemeKeyTextInvisibleCharactersColour : [self textInvisibleCharactersColor],
+		MGSColourSchemeKeyDefaultErrorHighlightingColor : [NSColor colorNamed:@"DefaultErrorHighlighting" bundle:[NSBundle bundleForClass:self]],
+		MGSColourSchemeKeyTextInvisibleCharactersColour : [NSColor colorNamed:@"TextInvisibleCharacters" bundle:[NSBundle bundleForClass:self]],
 		MGSColourSchemeKeyTextColor                     : [NSColor textColor],
 		MGSColourSchemeKeyBackgroundColor               : [NSColor textBackgroundColor],
 		MGSColourSchemeKeyInsertionPointColor           : [NSColor textColor],
-		MGSColourSchemeKeyCurrentLineHighlightColour    : [self keyCurrentLineHighlightColor]};
+		MGSColourSchemeKeyCurrentLineHighlightColour    : [NSColor colorNamed:@"KeyCurrentLineHighlight" bundle:[NSBundle bundleForClass:self]]};
 	NSDictionary *groupColors = @{
-		MGSSyntaxGroupAutoComplete : [self autoCompleteColor],
-		MGSSyntaxGroupAttribute    : [self attributeColor],
-		MGSSyntaxGroupCommand      : [self commandColor],
-		MGSSyntaxGroupComment      : [self commentColor],
-		MGSSyntaxGroupInstruction  : [self instructionColor],
-		MGSSyntaxGroupKeyword      : [self keywordColor],
-		MGSSyntaxGroupNumber       : [self numberColor],
-		MGSSyntaxGroupString       : [self stringColor],
-		MGSSyntaxGroupVariable     : [self variableColor]};
+		MGSSyntaxGroupAutoComplete : [NSColor colorNamed:@"AutoComplete" bundle:[NSBundle bundleForClass:self]],
+		MGSSyntaxGroupAttribute    : [NSColor colorNamed:@"Attribute" bundle:[NSBundle bundleForClass:self]],
+		MGSSyntaxGroupCommand      : [NSColor colorNamed:@"Command" bundle:[NSBundle bundleForClass:self]],
+		MGSSyntaxGroupComment      : [NSColor colorNamed:@"Comment" bundle:[NSBundle bundleForClass:self]],
+		MGSSyntaxGroupInstruction  : [NSColor colorNamed:@"Instruction" bundle:[NSBundle bundleForClass:self]],
+		MGSSyntaxGroupKeyword      : [NSColor colorNamed:@"Keyword" bundle:[NSBundle bundleForClass:self]],
+		MGSSyntaxGroupNumber       : [NSColor colorNamed:@"Number" bundle:[NSBundle bundleForClass:self]],
+		MGSSyntaxGroupString       : [NSColor colorNamed:@"String" bundle:[NSBundle bundleForClass:self]],
+		MGSSyntaxGroupVariable     : [NSColor colorNamed:@"Variable" bundle:[NSBundle bundleForClass:self]]};
     
     [common addEntriesFromDictionary:colors];
     NSMutableDictionary *groups = [NSMutableDictionary dictionary];


### PR DESCRIPTION
Fragaria was not able to react correctly to the automatic dark/light mode switch. The default colors were set at the initialization but not reload correctly when the switch occurred. A simple way to do that is to use the named colors with macOS 10.13 and more like this.